### PR TITLE
Testing Improvements

### DIFF
--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -112,8 +112,8 @@ class MuSpinInput(object):
             # A special case: if there are fitting variables, we need to know
             # right away
 
-            # if we find errors when parsing fitting variables, we post an error immediately
-            # so we don't propagate invalid variables when parsing keywords down the line
+            # if we find errors when parsing fitting variables, we post an error
+            # so we don't propagate invalid variables when parsing keywords later
             failed_status, errors = self._load_fitting_kw(raw_blocks, block_line_nums)
             if failed_status:
                 raise MuSpinInputError(

--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -206,7 +206,11 @@ class MuSpinInput(object):
                         )
                         result["couplings"][kwid] = val
             else:
-                if name in self._keywords:
+                # remove unnecessary keywords - stored in fitting_info
+                if name in ["fitting_data", "fitting_tolerance",
+                            "fitting_variables", "fitting_method"]:
+                    pass
+                elif name in self._keywords:
                     kw = self._keywords[name]
                     v = variables if issubclass(KWClass, MuSpinEvaluateKeyword) else {}
                     val = kw.evaluate(**v)

--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -205,8 +205,12 @@ class MuSpinInput(object):
                         result["couplings"][kwid] = val
             else:
                 # remove unnecessary keywords - stored in fitting_info
-                if name in ["fitting_data", "fitting_tolerance",
-                            "fitting_variables", "fitting_method"]:
+                if name in [
+                    "fitting_data",
+                    "fitting_tolerance",
+                    "fitting_variables",
+                    "fitting_method",
+                ]:
                     pass
                 elif name in self._keywords:
                     kw = self._keywords[name]

--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -111,13 +111,19 @@ class MuSpinInput(object):
             raw_blocks, block_line_nums = _make_blocks(fs)
             # A special case: if there are fitting variables, we need to know
             # right away
-            errors_found = []
+
+            # if we find errors when parsing fitting variables, we post an error immediately
+            # so we don't propagate invalid variables when parsing keywords down the line
             failed_status, errors = self._load_fitting_kw(raw_blocks, block_line_nums)
             if failed_status:
-                errors_found.extend(errors)
+                raise MuSpinInputError(
+                    "Found {0} Error(s) whilst trying to parse fitting keywords: "
+                    "\n\n{1}".format(len(errors), "\n\n".join(errors))
+                )
 
             # Another special case: if the "experiment" keyword is present,
             # use it to set some defaults
+            errors_found = []
             try:
                 block = raw_blocks.pop("experiment")
                 kw = InputKeywords["experiment"](block)
@@ -172,7 +178,7 @@ class MuSpinInput(object):
 
             if errors_found:
                 raise MuSpinInputError(
-                    "Found {0} Error(s) whilst trying to parse input file: "
+                    "Found {0} Error(s) whilst trying to parse keywords: "
                     "\n\n{1}".format(len(errors_found), "\n\n".join(errors_found))
                 )
 

--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -109,8 +109,6 @@ class MuSpinInput(object):
         if fs is not None:
 
             raw_blocks, block_line_nums = _make_blocks(fs)
-            # A special case: if there are fitting variables, we need to know
-            # right away
 
             # if we find errors when parsing fitting variables, we post an error
             # so we don't propagate invalid variables when parsing keywords later

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -94,8 +94,14 @@ class MuSpinKeyword(object):
             and not type(block[0] is np.ndarray)
             and block[0] in ("", None)
         ):
-            block = np.array([self.default.split("\n")])
-            use_default = True
+            if self.has_default:
+                block = np.array([self.default.split("\n")])
+                use_default = True
+            else:
+                raise RuntimeError(
+                    "Input is empty and keyword '{0}' "
+                    "doesn't have a default value".format(self.name)
+                )
 
         self._store_values(block)
 

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -375,8 +375,9 @@ class KWXAxis(MuSpinKeyword):
     accept_range = False
     default = "time"
     _validators = [
-        lambda s:
-        "Invalid value {0}, accepts {1}".format(s[0], [i for i in InputKeywords if InputKeywords[i].accept_as_x])
+        lambda s: "Invalid value {0}, accepts {1}".format(
+            s[0], [i for i in InputKeywords if InputKeywords[i].accept_as_x]
+        )
         if s[0] not in InputKeywords or not InputKeywords[s[0]].accept_as_x
         else ""
     ]
@@ -394,6 +395,7 @@ class KWYAxis(MuSpinKeyword):
         else ""
     ]
 
+
 class KWAverageAxes(MuSpinKeyword):
 
     name = "average_axes"
@@ -403,7 +405,7 @@ class KWAverageAxes(MuSpinKeyword):
     _validators = [
         lambda s: "Invalid value(s) '{0}': accepts {1}".format(
             [w for w in s if (w not in InputKeywords) or w.lower() == "None"],
-            InputKeywords
+            InputKeywords,
         )
         if not all((w in InputKeywords or w.lower() == "none") for w in s)
         else ""
@@ -502,11 +504,13 @@ class KWFittingVariables(MuSpinKeyword):
     default = ""
     _constants = {**_math_constants, **_phys_constants}
     _validators = [
-        lambda s:
-        "Invalid value '{0}': variable name conflicts with a constant".format(s.name)
+        lambda s: "Invalid value '{0}': variable name conflicts with a constant".format(
+            s.name
+        )
         if s.name in {**_math_constants, **_phys_constants}
         else ""
     ]
+
     def _store_values(self, block):
 
         variables = list(self._constants.keys())
@@ -550,10 +554,10 @@ class KWFittingMethod(MuSpinKeyword):
     accept_range = False
     default = "nelder-mead"
     _validators = [
-        lambda s:
-        "Invalid value {0}, accepted values {1}".format(
-            s[0].lower(), ['nelder-mead', 'lbfgs'])
-        if s[0].lower() not in ['nelder-mead', 'lbfgs']
+        lambda s: "Invalid value {0}, accepted values {1}".format(
+            s[0].lower(), ["nelder-mead", "lbfgs"]
+        )
+        if s[0].lower() not in ["nelder-mead", "lbfgs"]
         else ""
     ]
 
@@ -565,8 +569,7 @@ class KWFittingTolerance(MuSpinKeyword):
     accept_range = False
     default = "1e-3"
     _validators = [
-        lambda s:
-        "Invalid value '{0}', accepts only single float value".format(s[0])
+        lambda s: "Invalid value '{0}', accepts only single float value".format(s[0])
         if not float(s[0])
         else "",
     ]

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -89,7 +89,7 @@ class MuSpinKeyword(object):
             )
 
         use_default = False
-        if len(block) == 0 and self.has_default:
+        if len(block) == 0 or (len(block) == 1 and not type(block[0] is np.ndarray) and block[0] in ("", None)):
             block = np.array([self.default.split("\n")])
             use_default = True
 

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -89,7 +89,11 @@ class MuSpinKeyword(object):
             )
 
         use_default = False
-        if len(block) == 0 or (len(block) == 1 and not type(block[0] is np.ndarray) and block[0] in ("", None)):
+        if len(block) == 0 or (
+            len(block) == 1
+            and not type(block[0] is np.ndarray)
+            and block[0] in ("", None)
+        ):
             block = np.array([self.default.split("\n")])
             use_default = True
 

--- a/muspinsim/input/larkeval.py
+++ b/muspinsim/input/larkeval.py
@@ -83,6 +83,9 @@ class LarkExpression(object):
 
         # Start by parsing the expression
         self._source = source
+        # check if source empty
+        if source == "":
+            raise LarkExpressionError("Empty String")
         try:
             self._tree = _expr_parser.parse(source)
         except UnexpectedToken:
@@ -99,7 +102,7 @@ class LarkExpression(object):
         for v in self._variables:
             if v not in self._all_variables:
                 raise LarkExpressionError(
-                    "Invalid variable: '{0}', valid functions are ['{1}']".format(
+                    "Invalid variable: '{0}', valid variables are ['{1}']".format(
                         v, "', '".join(self._all_variables)
                     )
                 )

--- a/muspinsim/input/larkeval.py
+++ b/muspinsim/input/larkeval.py
@@ -102,7 +102,7 @@ class LarkExpression(object):
 
         self._variables = set(found_vars)
         self._functions = set(found_funcs)
-        self._all_variables = set(variables)
+        self._all_variables = set([variables] if isinstance(variables, str) else variables)
 
         # Check if they are valid
         for v in self._variables:

--- a/muspinsim/input/larkeval.py
+++ b/muspinsim/input/larkeval.py
@@ -102,7 +102,9 @@ class LarkExpression(object):
 
         self._variables = set(found_vars)
         self._functions = set(found_funcs)
-        self._all_variables = set([variables] if isinstance(variables, str) else variables)
+        self._all_variables = set(
+            [variables] if isinstance(variables, str) else variables
+        )
 
         # Check if they are valid
         for v in self._variables:

--- a/muspinsim/input/variables.py
+++ b/muspinsim/input/variables.py
@@ -15,14 +15,25 @@ class FittingVariable(object):
 
         invalid = ""
         if self._max <= self._min:
-            invalid += "Variable {0} has invalid range: " \
-                       "(max value {1} cannot be less than or equal to min value {2})\n".format(name, self._max, self._min)
+            invalid += (
+                "Variable {0} has invalid range: "
+                "(max value {1} cannot be less than or equal to min value {2}"
+                ")\n".format(name, self._max, self._min)
+            )
         if self._value > self._max:
-            invalid += "Variable {0} has invalid starting value: " \
-                        "(starting value {1} cannot be greater than max value {2})".format(name, self._value, self._max)
+            invalid += (
+                "Variable {0} has invalid starting value: "
+                "(starting value {1} cannot be greater than max value {2})".format(
+                    name, self._value, self._max
+                )
+            )
         if self._value < self._min:
-            invalid += "Variable {0} has invalid starting value: " \
-                        "(starting value {1} cannot be less than min value {2})".format(name, self._value, self._min)
+            invalid += (
+                "Variable {0} has invalid starting value: "
+                "(starting value {1} cannot be less than min value {2})".format(
+                    name, self._value, self._min
+                )
+            )
 
         if invalid != "":
             raise ValueError(invalid)

--- a/muspinsim/input/variables.py
+++ b/muspinsim/input/variables.py
@@ -13,10 +13,19 @@ class FittingVariable(object):
         self._min = float(minv)
         self._max = float(maxv)
 
+        invalid = ""
         if self._max <= self._min:
-            raise ValueError("Variable {0} has invalid range".format(name))
-        elif self._value > self._max or self._value < self._min:
-            raise ValueError("Variable {0} has invalid starting " "value".format(name))
+            invalid += "Variable {0} has invalid range: " \
+                       "(max value {1} cannot be less than or equal to min value {2})\n".format(name, self._max, self._min)
+        if self._value > self._max:
+            invalid += "Variable {0} has invalid starting value: " \
+                        "(starting value {1} cannot be greater than max value {2})".format(name, self._value, self._max)
+        if self._value < self._min:
+            invalid += "Variable {0} has invalid starting value: " \
+                        "(starting value {1} cannot be less than min value {2})".format(name, self._value, self._min)
+
+        if invalid != "":
+            raise ValueError(invalid)
 
     @property
     def name(self):

--- a/muspinsim/simconfig.py
+++ b/muspinsim/simconfig.py
@@ -279,12 +279,6 @@ class MuSpinConfig(object):
             "Total number of configurations to average: " "{0}".format(self._avg_N)
         )
 
-        # Define a namedtuple for configurations
-        cfg_keys = list(self._constants.keys())
-        cfg_keys += list(self._file_ranges.keys())
-        cfg_keys += list(self._avg_ranges.keys())
-        cfg_keys += list(self._x_range.keys())
-
     def validate(self, name, value, args={}):
         """Validate an input parameter with a custom method, if present.
 

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -8,14 +8,18 @@ class TestConstants(unittest.TestCase):
 
         self.assertAlmostEqual(constants.ELEC_GAMMA, -28024.9514242)
         self.assertAlmostEqual(constants.MU_GAMMA, 135.53880943285955)
+        self.assertAlmostEqual(constants.MU_TAU, 2.19703)
+        self.assertAlmostEqual(constants.EFG_2_MHZ, 0.23496477815245767)
 
     def test_gyromagnetic(self):
 
         self.assertEqual(constants.gyromagnetic_ratio("e"), constants.ELEC_GAMMA)
+        self.assertEqual(constants.gyromagnetic_ratio("mu"), constants.MU_GAMMA)
         self.assertAlmostEqual(constants.gyromagnetic_ratio("H"), 42.577478518, 3)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as err:
             constants.gyromagnetic_ratio("H", 4)
+        self.assertEqual(str(err.exception), "Invalid isotope 4 for element H")
 
     def test_quadrupole(self):
 
@@ -23,8 +27,21 @@ class TestConstants(unittest.TestCase):
         self.assertEqual(constants.quadrupole_moment("H"), 0)
         self.assertAlmostEqual(constants.quadrupole_moment("H", 2), 2.859, 2)
 
+        with self.assertRaises(ValueError) as err:
+            constants.gyromagnetic_ratio("H", 4)
+        self.assertEqual(str(err.exception), "Invalid isotope 4 for element H")
+
     def test_spin(self):
 
+        self.assertEqual(constants.spin("mu"), 0.5)
         self.assertEqual(constants.spin("e"), 0.5)
         self.assertEqual(constants.spin("H"), 0.5)
         self.assertEqual(constants.spin("H", 2), 1.0)
+
+        with self.assertRaises(ValueError) as err:
+            constants.spin("H", 4)
+        self.assertEqual(str(err.exception), "Invalid isotope 4 for element H")
+
+        with self.assertRaises(ValueError) as err:
+            constants.spin("e", 0.5)
+        self.assertEqual(str(err.exception), "Invalid multiplicity 0.5 for electron")

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -96,7 +96,7 @@ class TestInput(unittest.TestCase):
         with self.assertRaises(LarkExpressionError) as err:
             e4 = LarkExpression("x+1", variables="y")
         self.assertEqual(
-            str(err.exception), "Invalid variable: 'x', valid variables are ['y']"
+            str(err.exception), "Invalid variable/constant: 'x', valid variables/constants are ['y']"
         )
 
         # value of variable not given when evaluating
@@ -105,8 +105,8 @@ class TestInput(unittest.TestCase):
             e5.evaluate()
         self.assertEqual(
             str(err.exception),
-            "Some necessary variables have not been defined when "
-            "evaluating LarkExpression",
+            "Some necessary variable(s) {'x'} have not been defined "
+            "when evaluating LarkExpression"
         )
 
         # invalid variable value given when evaluating
@@ -115,7 +115,7 @@ class TestInput(unittest.TestCase):
             e5.evaluate(x=1, y=1)
         self.assertEqual(
             str(err.exception),
-            "Some invalid variables have been defined when "
+            "Some invalid variable(s) {'y'} have been defined when "
             "evaluating LarkExpression",
         )
 
@@ -224,8 +224,7 @@ class TestInput(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             ykw = InputKeywords["y_axis"](["something"])
         self.assertEqual(
-            str(err.exception), "Invalid block for keyword y_axis: Invalid value, accepted values "
-                                "['asymmetry', 'integral']"
+            str(err.exception), "Invalid value '['something']', accepts ['asymmetry', 'integral']"
         )
 
         ykw = InputKeywords["y_axis"](["asymmetry"])
@@ -473,6 +472,9 @@ zeeman 1
 """
                 )
             )
-        self.assertTrue(
-            "Variable names {'MHz'} conflict with existing constants" in str(err.exception)
+        self.assertEqual(
+            str(err.exception),
+            "Found 1 Error(s) whilst trying to parse fitting keywords: \n\n"
+            "Error occurred when parsing keyword 'fitting_variables' (block starting at line 2):\n"
+            "Invalid value 'MHz': variable name conflicts with a constant"
         )

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -29,6 +29,14 @@ class TestInput(unittest.TestCase):
 
         self.assertEqual(DefKeyword().evaluate()[0][0], "1")
 
+    def test_no_defaults(self):
+        with self.assertRaises(RuntimeError) as err:
+            MuSpinKeyword()
+        self.assertEqual(
+            str(err.exception),
+            "Input is empty and keyword " "'keyword' doesn't have a default value",
+        )
+
     def test_evaluate_keyword(self):
         nkw = MuSpinEvaluateKeyword(["exp(0) 1+1 2^2"])
         self.assertTrue((nkw.evaluate()[0] == [1, 2, 4]).all())

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -58,7 +58,7 @@ class TestInput(unittest.TestCase):
                 "larkexpr": "3*",
                 "funcs": {},
                 "invalid": True,
-                "out": "Invalid characters in LarkExpression",
+                "out": "Invalid characters in LarkExpression: Unexpected token"
             },
             # empty expression
             {"larkexpr": "", "funcs": {}, "invalid": True, "out": "Empty String"},
@@ -72,7 +72,7 @@ class TestInput(unittest.TestCase):
             else:
                 with self.assertRaises(LarkExpressionError) as err:
                     e1 = LarkExpression(test["larkexpr"], functions=test["funcs"])
-                self.assertEqual(str(err.exception), test["out"])
+                self.assertTrue(test["out"] in str(err.exception))
 
     def test_larkexpr_var(self):
 
@@ -176,7 +176,7 @@ class TestInput(unittest.TestCase):
         with self.assertRaises(RuntimeError) as err:
             MuSpinKeyword([], args=["a"])  # One argument too much
         self.assertEqual(
-            str(err.exception), "Wrong number of arguments passed to keyword keyword"
+            str(err.exception), "Wrong number of in-line arguments given 'a', expected 0, got 1"
         )
 
     def test_input_keywords(self):
@@ -224,7 +224,8 @@ class TestInput(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             ykw = InputKeywords["y_axis"](["something"])
         self.assertEqual(
-            str(err.exception), "Invalid block for keyword y_axis: Invalid value"
+            str(err.exception), "Invalid block for keyword y_axis: Invalid value, accepted values "
+                                "['asymmetry', 'integral']"
         )
 
         ykw = InputKeywords["y_axis"](["asymmetry"])
@@ -257,7 +258,9 @@ class TestInput(unittest.TestCase):
         with self.assertRaises(RuntimeError) as err:
             InputKeywords["zeeman"]([], args=["wrong"])
         self.assertEqual(
-            str(err.exception), "Invalid argument type passed to keyword zeeman"
+            str(err.exception), "Error parsing keyword argument(s) 'zeeman': "
+                                "invalid literal for int() with "
+                                "base 10: 'wrong'"
         )
 
     def test_read_block(self):
@@ -330,7 +333,9 @@ notakeyword 1
                 )
             ).evaluate()
         self.assertEqual(
-            str(err.exception), "Invalid keyword notakeyword found in input file"
+            str(err.exception), "Found 1 Error(s) whilst trying to parse keywords: \n\n"
+                                "Error occurred when parsing keyword 'notakeyword' (block starting at line 6):\n"
+                                "Invalid keyword notakeyword found in input file"
         )
 
     def test_fitting(self):
@@ -417,11 +422,13 @@ fitting_variables
             )
         self.assertEqual(
             str(err.exception),
-            "Fitting variables defined without defining a set of data to fit",
+            "Found 1 Error(s) whilst trying to parse fitting keywords: \n\n"
+            "Error occurred when parsing keyword 'fitting_variables' (block starting at line 2):\n"
+            "Fitting variables defined without defining any data to fit",
         )
 
         # invalid variable range
-        with self.assertRaises(ValueError) as err:
+        with self.assertRaises(MuSpinInputError) as err:
             MuSpinInput(
                 StringIO(
                     """
@@ -440,16 +447,15 @@ zeeman 1
                     )
                 )
             )
-        self.assertEqual(
-            str(err.exception),
+        self.assertTrue(
             "Variable x has invalid range: "
             "(max value -5.0 cannot be less than or equal to min value 0.0)\n"
             "Variable x has invalid starting value: "
-            "(starting value 1.0 cannot be greater than max value -5.0)",
+            "(starting value 1.0 cannot be greater than max value -5.0)" in str(err.exception)
         )
 
         # variable name clashes with constant
-        with self.assertRaises(ValueError) as err:
+        with self.assertRaises(MuSpinInputError) as err:
             MuSpinInput(
                 StringIO(
                     """
@@ -467,7 +473,6 @@ zeeman 1
 """
                 )
             )
-        self.assertEqual(
-            str(err.exception),
-            "Variable names {'MHz'} conflict with existing constants",
+        self.assertTrue(
+            "Variable names {'MHz'} conflict with existing constants" in str(err.exception)
         )

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -15,7 +15,6 @@ from muspinsim.input import MuSpinInput
 
 
 class TestInput(unittest.TestCase):
-
     def test_basic_keyword(self):
         # Basic keyword
         kw = MuSpinKeyword(["a b c", "d e f"])
@@ -69,125 +68,152 @@ class TestInput(unittest.TestCase):
         self.assertTrue((kw.evaluate() == test["out"]).all())
 
         self.assertEqual(
-            kw.id,
-            test["kw"] + "".join(["_{0}".format(i) for i in test["args"]])
+            kw.id, test["kw"] + "".join(["_{0}".format(i) for i in test["args"]])
         )
 
     def test_keyword_name(self):
-        self._eval_kw({
-            "kw": "name",
-            "args": [],
-            "in": ["othername"],
-            "out": "othername",
-        })
+        self._eval_kw(
+            {
+                "kw": "name",
+                "args": [],
+                "in": ["othername"],
+                "out": "othername",
+            }
+        )
 
     def test_keyword_name_defaults(self):
-        self._eval_kw({
-            "kw": "name",
-            "args": [],
-            "in": [],
-            "out": "muspinsim",
-        })
+        self._eval_kw(
+            {
+                "kw": "name",
+                "args": [],
+                "in": [],
+                "out": "muspinsim",
+            }
+        )
 
     def test_keyword_spins(self):
-        self._eval_kw({
-            "kw": "spins",
-            "args": [],
-            "in": ["F mu F"],
-            "out": np.array(["F", "mu", "F"]),
-        })
+        self._eval_kw(
+            {
+                "kw": "spins",
+                "args": [],
+                "in": ["F mu F"],
+                "out": np.array(["F", "mu", "F"]),
+            }
+        )
 
     def test_keyword_spins_defaults(self):
-        self._eval_kw({
-            "kw": "spins",
-            "args": [],
-            "in": [],
-            "out": np.array(["mu", "e"]),
-        })
+        self._eval_kw(
+            {
+                "kw": "spins",
+                "args": [],
+                "in": [],
+                "out": np.array(["mu", "e"]),
+            }
+        )
 
     def test_keyword_polarization(self):
-        self._eval_kw({
-            "kw": "polarization",
-            "args": [],
-            "in": ["0 1 1"],
-            "out": np.array([0, 1, 1]),
-        })
+        self._eval_kw(
+            {
+                "kw": "polarization",
+                "args": [],
+                "in": ["0 1 1"],
+                "out": np.array([0, 1, 1]),
+            }
+        )
 
     def test_keyword_polarization_defaults(self):
-        self._eval_kw({
-            "kw": "polarization",
-            "args": [],
-            "in": [],
-            "out": np.array([1, 0, 0]),
-        })
+        self._eval_kw(
+            {
+                "kw": "polarization",
+                "args": [],
+                "in": [],
+                "out": np.array([1, 0, 0]),
+            }
+        )
 
     def test_keyword_polarization_longditudinal(self):
-        self._eval_kw({
-            "kw": "polarization",
-            "args": [],
-            "in": ["longitudinal"],
-            "out": np.array([0, 0, 1.0]),
-        })
+        self._eval_kw(
+            {
+                "kw": "polarization",
+                "args": [],
+                "in": ["longitudinal"],
+                "out": np.array([0, 0, 1.0]),
+            }
+        )
 
     def test_keyword_polarization_transverse(self):
-        self._eval_kw({
-            "kw": "polarization",
-            "args": [],
-            "in": ["transverse"],
-            "out": np.array([1.0, 0, 0]),
-        })
+        self._eval_kw(
+            {
+                "kw": "polarization",
+                "args": [],
+                "in": ["transverse"],
+                "out": np.array([1.0, 0, 0]),
+            }
+        )
 
     def test_keyword_field_range(self):
-        self._eval_kw({
-            "kw": "field",
-            "args": [],
-            "in": ["range(0, 20, 21)"],
-            "out": np.arange(21)[:, None],
-        })
+        self._eval_kw(
+            {
+                "kw": "field",
+                "args": [],
+                "in": ["range(0, 20, 21)"],
+                "out": np.arange(21)[:, None],
+            }
+        )
 
     def test_keyword_field_mhz(self):
         kw = InputKeywords["field"](["500*MHz"])
         self.assertTrue(np.isclose(kw.evaluate()[0][0], 1.84449016))
 
     def test_keyword_field_defaults(self):
-        self._eval_kw({
-            "kw": "field",
-            "args": [],
-            "in": [],
-            "out": np.array([0]),
-        })
+        self._eval_kw(
+            {
+                "kw": "field",
+                "args": [],
+                "in": [],
+                "out": np.array([0]),
+            }
+        )
 
     def test_keyword_time_defaults(self):
-        self._eval_kw({
-            "kw": "time",
-            "args": [],
-            "in": [],
-            "out": np.linspace(0, 10, 101)[:, None],
-        })
+        self._eval_kw(
+            {
+                "kw": "time",
+                "args": [],
+                "in": [],
+                "out": np.linspace(0, 10, 101)[:, None],
+            }
+        )
 
     def test_keyword_time_range(self):
-        self._eval_kw({
-            "kw": "time",
-            "args": [],
-            "in": ["range(0, 10, 5)"],
-            "out": np.array([0, 2.5, 5, 7.5, 10])[:, None],
-        })
+        self._eval_kw(
+            {
+                "kw": "time",
+                "args": [],
+                "in": ["range(0, 10, 5)"],
+                "out": np.array([0, 2.5, 5, 7.5, 10])[:, None],
+            }
+        )
 
     def test_keyword_time_multi_line(self):
-        self._eval_kw({
-            "kw": "time",
-            "args": [],
-            "in": ["10", "20", "30", "range(0, 10, 5)"],
-            "out": np.array([10, 20, 30, 0, 2.5, 5, 7.5, 10])[:, None],
-        })
+        self._eval_kw(
+            {
+                "kw": "time",
+                "args": [],
+                "in": ["10", "20", "30", "range(0, 10, 5)"],
+                "out": np.array([10, 20, 30, 0, 2.5, 5, 7.5, 10])[:, None],
+            }
+        )
 
     def test_keyword_y_axis(self):
-        self._eval_kw({
-            "kw": "y_axis",
-            "args": [],
-            "in": ["asymmetry"],
-            "out": np.array(["asymmetry"]),
-        })
+        self._eval_kw(
+            {
+                "kw": "y_axis",
+                "args": [],
+                "in": ["asymmetry"],
+                "out": np.array(["asymmetry"]),
+            }
+        )
 
     def test_keyword_y_axis_invalid(self):
         with self.assertRaises(ValueError) as err:
@@ -198,72 +224,88 @@ class TestInput(unittest.TestCase):
         )
 
     def test_keyword_y_axis_defaults(self):
-        self._eval_kw({
-            "kw": "y_axis",
-            "args": [],
-            "in": [],
-            "out": np.array(["asymmetry"]),
-        })
+        self._eval_kw(
+            {
+                "kw": "y_axis",
+                "args": [],
+                "in": [],
+                "out": np.array(["asymmetry"]),
+            }
+        )
 
     def test_keyword_orientation_zcw(self):
         kw = InputKeywords["orientation"](["zcw(20)"])
         self.assertTrue(len(kw.evaluate()) >= 20)
 
     def test_keyword_orientation_defaults(self):
-        self._eval_kw({
-            "kw": "orientation",
-            "args": [],
-            "in": [],
-            "out": np.array([0, 0, 0]),
-        })
+        self._eval_kw(
+            {
+                "kw": "orientation",
+                "args": [],
+                "in": [],
+                "out": np.array([0, 0, 0]),
+            }
+        )
 
     def test_keyword_zeeman(self):
-        self._eval_kw({
-            "kw": "zeeman",
-            "args": ["1"],
-            "in": ["0 0 1"],
-            "out": np.array([0, 0, 1]),
-        })
+        self._eval_kw(
+            {
+                "kw": "zeeman",
+                "args": ["1"],
+                "in": ["0 0 1"],
+                "out": np.array([0, 0, 1]),
+            }
+        )
 
     def test_keyword_zeeman_defaults(self):
-        self._eval_kw({
-            "kw": "zeeman",
-            "args": ["1"],
-            "in": [],
-            "out": np.array([0, 0, 0]),
-        })
+        self._eval_kw(
+            {
+                "kw": "zeeman",
+                "args": ["1"],
+                "in": [],
+                "out": np.array([0, 0, 0]),
+            }
+        )
 
     def test_keyword_hyperfine(self):
-        self._eval_kw({
-            "kw": "hyperfine",
-            "args": ["1"],
-            "in": ["1 0 0", "0 1 0", "0 0 1"],
-            "out": np.array([[1, 0, 0],[0, 1, 0],[0, 0, 1]]),
-        })
+        self._eval_kw(
+            {
+                "kw": "hyperfine",
+                "args": ["1"],
+                "in": ["1 0 0", "0 1 0", "0 0 1"],
+                "out": np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            }
+        )
 
     def test_keyword_hyperfine_defaults(self):
-        self._eval_kw({
-            "kw": "hyperfine",
-            "args": ["1"],
-            "in": [],
-            "out": np.zeros((3, 3)),
-        })
+        self._eval_kw(
+            {
+                "kw": "hyperfine",
+                "args": ["1"],
+                "in": [],
+                "out": np.zeros((3, 3)),
+            }
+        )
 
     def test_keyword_dipolar(self):
-        self._eval_kw({
-            "kw": "dipolar",
-            "args": ["1", "2"],
-            "in": ["0 0 1"],
-            "out": np.array([0, 0, 1]),
-        })
+        self._eval_kw(
+            {
+                "kw": "dipolar",
+                "args": ["1", "2"],
+                "in": ["0 0 1"],
+                "out": np.array([0, 0, 1]),
+            }
+        )
 
     def test_keyword_dipolar_defaults(self):
-        self._eval_kw({
-            "kw": "dipolar",
-            "args": ["1", "2"],
-            "in": [],
-            "out": np.array([0, 0, 0]),
-        })
+        self._eval_kw(
+            {
+                "kw": "dipolar",
+                "args": ["1", "2"],
+                "in": [],
+                "out": np.array([0, 0, 0]),
+            }
+        )
 
     def test_keyword_quadrupolar(self):
         kw = InputKeywords["quadrupolar"](
@@ -274,13 +316,14 @@ class TestInput(unittest.TestCase):
 
     def test_keyword_quadrupolar_defaults(self):
 
-        self._eval_kw({
-            "kw": "zeeman",
-            "args": ["1"],
-            "in": [],
-            "out": np.array([0, 0, 0]),
-        })
-
+        self._eval_kw(
+            {
+                "kw": "zeeman",
+                "args": ["1"],
+                "in": [],
+                "out": np.array([0, 0, 0]),
+            }
+        )
 
     def test_input_valid(self):
         # read valid file
@@ -433,7 +476,6 @@ fitting_method
         self.assertTrue((data == tdata).all())
         self.assertEqual(finfo["method"], "nelder-mead")
         self.assertAlmostEqual(finfo["rtol"], 1e-3)
-
 
     def test_fitting_no_data(self):
         # invalid no data given

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -64,7 +64,7 @@ class TestInput(unittest.TestCase):
 
     def test_invalid_args(self):
         with self.assertRaises(RuntimeError) as err:
-            MuSpinCouplingKeyword([], args=["a"])  # One argument too much
+            MuSpinCouplingKeyword([], args=["a"])  # Wrong argument type
         self.assertEqual(
             str(err.exception),
             "Error parsing keyword argument(s) 'coupling_keyword': invalid literal for "
@@ -225,7 +225,7 @@ class TestInput(unittest.TestCase):
 
     def test_keyword_y_axis_invalid(self):
         with self.assertRaises(ValueError) as err:
-            InputKeywords["y_axis"](["something"], args=[])  # One argument too much
+            InputKeywords["y_axis"](["something"], args=[])  # Invalid value for argument
         self.assertEqual(
             str(err.exception),
             "Invalid value '['something']', accepts ['asymmetry', 'integral']",

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -58,7 +58,7 @@ class TestInput(unittest.TestCase):
                 "larkexpr": "3*",
                 "funcs": {},
                 "invalid": True,
-                "out": "Invalid characters in LarkExpression: Unexpected token"
+                "out": "Invalid characters in LarkExpression: Unexpected token",
             },
             # empty expression
             {"larkexpr": "", "funcs": {}, "invalid": True, "out": "Empty String"},
@@ -96,7 +96,8 @@ class TestInput(unittest.TestCase):
         with self.assertRaises(LarkExpressionError) as err:
             e4 = LarkExpression("x+1", variables="y")
         self.assertEqual(
-            str(err.exception), "Invalid variable/constant: 'x', valid variables/constants are ['y']"
+            str(err.exception),
+            "Invalid variable/constant: 'x', valid variables/constants are ['y']",
         )
 
         # value of variable not given when evaluating
@@ -106,7 +107,7 @@ class TestInput(unittest.TestCase):
         self.assertEqual(
             str(err.exception),
             "Some necessary variable(s) {'x'} have not been defined "
-            "when evaluating LarkExpression"
+            "when evaluating LarkExpression",
         )
 
         # invalid variable value given when evaluating
@@ -176,7 +177,8 @@ class TestInput(unittest.TestCase):
         with self.assertRaises(RuntimeError) as err:
             MuSpinKeyword([], args=["a"])  # One argument too much
         self.assertEqual(
-            str(err.exception), "Wrong number of in-line arguments given 'a', expected 0, got 1"
+            str(err.exception),
+            "Wrong number of in-line arguments given 'a', expected 0, got 1",
         )
 
     def test_input_keywords(self):
@@ -224,7 +226,8 @@ class TestInput(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             ykw = InputKeywords["y_axis"](["something"])
         self.assertEqual(
-            str(err.exception), "Invalid value '['something']', accepts ['asymmetry', 'integral']"
+            str(err.exception),
+            "Invalid value '['something']', accepts ['asymmetry', 'integral']",
         )
 
         ykw = InputKeywords["y_axis"](["asymmetry"])
@@ -257,9 +260,10 @@ class TestInput(unittest.TestCase):
         with self.assertRaises(RuntimeError) as err:
             InputKeywords["zeeman"]([], args=["wrong"])
         self.assertEqual(
-            str(err.exception), "Error parsing keyword argument(s) 'zeeman': "
-                                "invalid literal for int() with "
-                                "base 10: 'wrong'"
+            str(err.exception),
+            "Error parsing keyword argument(s) 'zeeman': "
+            "invalid literal for int() with "
+            "base 10: 'wrong'",
         )
 
     def test_read_block(self):
@@ -332,9 +336,11 @@ notakeyword 1
                 )
             ).evaluate()
         self.assertEqual(
-            str(err.exception), "Found 1 Error(s) whilst trying to parse keywords: \n\n"
-                                "Error occurred when parsing keyword 'notakeyword' (block starting at line 6):\n"
-                                "Invalid keyword notakeyword found in input file"
+            str(err.exception),
+            "Found 1 Error(s) whilst trying to parse keywords: \n\n"
+            "Error occurred when parsing keyword 'notakeyword' "
+            "(block starting at line 6):\n"
+            "Invalid keyword notakeyword found in input file",
         )
 
     def test_fitting(self):
@@ -422,7 +428,8 @@ fitting_variables
         self.assertEqual(
             str(err.exception),
             "Found 1 Error(s) whilst trying to parse fitting keywords: \n\n"
-            "Error occurred when parsing keyword 'fitting_variables' (block starting at line 2):\n"
+            "Error occurred when parsing keyword 'fitting_variables' "
+            "(block starting at line 2):\n"
             "Fitting variables defined without defining any data to fit",
         )
 
@@ -450,7 +457,8 @@ zeeman 1
             "Variable x has invalid range: "
             "(max value -5.0 cannot be less than or equal to min value 0.0)\n"
             "Variable x has invalid starting value: "
-            "(starting value 1.0 cannot be greater than max value -5.0)" in str(err.exception)
+            "(starting value 1.0 cannot be greater than max value -5.0)"
+            in str(err.exception)
         )
 
         # variable name clashes with constant
@@ -475,6 +483,7 @@ zeeman 1
         self.assertEqual(
             str(err.exception),
             "Found 1 Error(s) whilst trying to parse fitting keywords: \n\n"
-            "Error occurred when parsing keyword 'fitting_variables' (block starting at line 2):\n"
-            "Invalid value 'MHz': variable name conflicts with a constant"
+            "Error occurred when parsing keyword 'fitting_variables' "
+            "(block starting at line 2):\n"
+            "Invalid value 'MHz': variable name conflicts with a constant",
         )

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -225,7 +225,9 @@ class TestInput(unittest.TestCase):
 
     def test_keyword_y_axis_invalid(self):
         with self.assertRaises(ValueError) as err:
-            InputKeywords["y_axis"](["something"], args=[])  # Invalid value for argument
+            InputKeywords["y_axis"](
+                ["something"], args=[]
+            )  # Invalid value for argument
         self.assertEqual(
             str(err.exception),
             "Invalid value '['something']', accepts ['asymmetry', 'integral']",

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -12,28 +12,55 @@ from muspinsim.input.keyword import (
 )
 from muspinsim.input.input import MuSpinInput, MuSpinInputError
 
+
 class TestInput(unittest.TestCase):
     def test_larkexpr(self):
-        """ Lark expression unit test """
+        """Lark expression unit test"""
 
         def double(x):
             return 2 * x
 
         larktests = [
             # read expression
-            {"larkexpr": "3+2*6^2/9", "funcs": {}, "invalid":False, "out":11},
+            {"larkexpr": "3+2*6^2/9", "funcs": {}, "invalid": False, "out": 11},
             # read function - double
-            {"larkexpr": "double(2)", "funcs": {"double": double}, "invalid":False, "out": 4},
+            {
+                "larkexpr": "double(2)",
+                "funcs": {"double": double},
+                "invalid": False,
+                "out": 4,
+            },
             # read expression within function
-            {"larkexpr": "double(3+2*6^2/9)", "funcs": {"double": double}, "invalid":False, "out": 22},
+            {
+                "larkexpr": "double(3+2*6^2/9)",
+                "funcs": {"double": double},
+                "invalid": False,
+                "out": 22,
+            },
             # read expression composed of multiple functions
-            {"larkexpr": "double(3+2* 6^2/9) - double(2 *5)", "funcs": {"double": double}, "invalid": False, "out": 2},
+            {
+                "larkexpr": "double(3+2* 6^2/9) - double(2 *5)",
+                "funcs": {"double": double},
+                "invalid": False,
+                "out": 2,
+            },
             # invalid function
-            {"larkexpr": "notafunc(123)", "funcs": {"double": double}, "invalid": True, "out": "Invalid function: 'notafunc()', valid functions are ['double()']"},
+            {
+                "larkexpr": "notafunc(123)",
+                "funcs": {"double": double},
+                "invalid": True,
+                "out": "Invalid function: 'notafunc()', "
+                "valid functions are ['double()']",
+            },
             # invalid expression
-            {"larkexpr": "3*", "funcs": {}, "invalid": True, "out": "Invalid characters in LarkExpression"},
+            {
+                "larkexpr": "3*",
+                "funcs": {},
+                "invalid": True,
+                "out": "Invalid characters in LarkExpression",
+            },
             # empty expression
-            {"larkexpr": "", "funcs": {}, "invalid": True, "out": "Empty String"}
+            {"larkexpr": "", "funcs": {}, "invalid": True, "out": "Empty String"},
         ]
 
         for test in larktests:
@@ -67,19 +94,29 @@ class TestInput(unittest.TestCase):
         # lark expression does not contain variable given
         with self.assertRaises(LarkExpressionError) as err:
             e4 = LarkExpression("x+1", variables="y")
-        self.assertEqual(str(err.exception), "Invalid variable: 'x', valid variables are ['y']")
+        self.assertEqual(
+            str(err.exception), "Invalid variable: 'x', valid variables are ['y']"
+        )
 
         # value of variable not given when evaluating
         with self.assertRaises(LarkExpressionError) as err:
             e5 = LarkExpression("x+1", variables="x")
             e5.evaluate()
-        self.assertEqual(str(err.exception), "Some necessary variables have not been defined when evaluating LarkExpression")
+        self.assertEqual(
+            str(err.exception),
+            "Some necessary variables have not been defined when "
+            "evaluating LarkExpression",
+        )
 
         # invalid variable value given when evaluating
         with self.assertRaises(LarkExpressionError) as err:
             e5 = LarkExpression("x+1", variables="x")
             e5.evaluate(x=1, y=1)
-        self.assertEqual(str(err.exception), "Some invalid variables have been defined when evaluating LarkExpression")
+        self.assertEqual(
+            str(err.exception),
+            "Some invalid variables have been defined when "
+            "evaluating LarkExpression",
+        )
 
     def test_tokenization(self):
         tokens = lark_tokenize("3+0.4 2.3 sin(x) atan2(3, 4)")
@@ -137,7 +174,9 @@ class TestInput(unittest.TestCase):
         # Some failure cases
         with self.assertRaises(RuntimeError) as err:
             MuSpinKeyword([], args=["a"])  # One argument too much
-        self.assertEqual(str(err.exception), "Wrong number of arguments passed to keyword keyword")
+        self.assertEqual(
+            str(err.exception), "Wrong number of arguments passed to keyword keyword"
+        )
 
     def test_input_keywords(self):
 
@@ -183,7 +222,9 @@ class TestInput(unittest.TestCase):
 
         with self.assertRaises(ValueError) as err:
             ykw = InputKeywords["y_axis"](["something"])
-        self.assertEqual(str(err.exception), "Invalid block for keyword y_axis: Invalid value")
+        self.assertEqual(
+            str(err.exception), "Invalid block for keyword y_axis: Invalid value"
+        )
 
         ykw = InputKeywords["y_axis"](["asymmetry"])
 
@@ -214,40 +255,52 @@ class TestInput(unittest.TestCase):
         # Failure case (wrong argument type)
         with self.assertRaises(RuntimeError) as err:
             InputKeywords["zeeman"]([], args=["wrong"])
-        self.assertEqual(str(err.exception), "Invalid argument type passed to keyword zeeman")
+        self.assertEqual(
+            str(err.exception), "Invalid argument type passed to keyword zeeman"
+        )
 
     def test_read_block(self):
-            """test read input file unit test"""
+        """test read input file unit test"""
 
-            # read valid file
-            e1 = MuSpinInput(StringIO("""
+        # read valid file
+        e1 = MuSpinInput(
+            StringIO(
+                """
 name
     test_1
 spins
     mu H
 zeeman 1
     1 0 0
-""")).evaluate()
+"""
+            )
+        ).evaluate()
 
-            self.assertEqual(e1["name"].value[0], "test_1")
-            self.assertTrue((e1["spins"].value[0] == ["mu", "H"]).all())
-            self.assertTrue((e1["couplings"]["zeeman_1"].value[0] == [1, 0, 0]).all())
+        self.assertEqual(e1["name"].value[0], "test_1")
+        self.assertTrue((e1["spins"].value[0] == ["mu", "H"]).all())
+        self.assertTrue((e1["couplings"]["zeeman_1"].value[0] == [1, 0, 0]).all())
 
-            # read improperly formatted file
-            with self.assertRaises(RuntimeError) as err:
-                e2 = MuSpinInput(StringIO("""
+        # read improperly formatted file
+        with self.assertRaises(RuntimeError) as err:
+            MuSpinInput(
+                StringIO(
+                    """
     name
         test_1
 spins
     mu H
 zeeman 1
     1 0 0
-""")).evaluate()
-            self.assertEqual(str(err.exception), "Badly formatted input file")
+"""
+                )
+            ).evaluate()
+        self.assertEqual(str(err.exception), "Badly formatted input file")
 
-            # indent in between keyword values does not match
-            with self.assertRaises(RuntimeError) as err:
-                e4 = MuSpinInput(StringIO("""
+        # indent in between keyword values does not match
+        with self.assertRaises(RuntimeError) as err:
+            MuSpinInput(
+                StringIO(
+                    """
 name
     test_1
 spins
@@ -256,26 +309,35 @@ hyperfine 1
     1 0 0
      2 0 0
     3 0 0
-""")).evaluate()
-            self.assertEqual(str(err.exception), "Invalid indent in input file")
+"""
+                )
+            ).evaluate()
+        self.assertEqual(str(err.exception), "Invalid indent in input file")
 
-            # incorrect keyword name given
-            with self.assertRaises(MuSpinInputError) as err:
-                e5 = MuSpinInput(StringIO("""
+        # incorrect keyword name given
+        with self.assertRaises(MuSpinInputError) as err:
+            MuSpinInput(
+                StringIO(
+                    """
 name
     test_1
 spins
     mu H
 notakeyword 1
     1 0 0
-""")).evaluate()
-            self.assertEqual(str(err.exception), "Invalid keyword notakeyword found in input file")
+"""
+                )
+            ).evaluate()
+        self.assertEqual(
+            str(err.exception), "Invalid keyword notakeyword found in input file"
+        )
 
     def test_fitting(self):
         # Test input focused around fitting
 
-        i1 = MuSpinInput(StringIO(
-            """
+        i1 = MuSpinInput(
+            StringIO(
+                """
 fitting_variables
     x 1.0 0.0 2.0
 fitting_data
@@ -288,7 +350,8 @@ field
 zeeman 1
     x x 0
 """
-        ))
+            )
+        )
 
         self.assertTrue(i1.fitting_info["fit"])
 
@@ -316,15 +379,20 @@ zeeman 1
         tfile.flush()
         tfile.close()
 
-        i2 = MuSpinInput(StringIO("""
+        i2 = MuSpinInput(
+            StringIO(
+                """
 fitting_variables
     x
 fitting_data
     load("{fname}")
 fitting_method
     nelder-mead
-""".format(fname=tfile.name)
-        ))
+""".format(
+                    fname=tfile.name
+                )
+            )
+        )
 
         finfo = i2.fitting_info
 
@@ -338,16 +406,24 @@ fitting_method
 
         # invalid no data given
         with self.assertRaises(MuSpinInputError) as err:
-            i3 = MuSpinInput(StringIO("""
+            MuSpinInput(
+                StringIO(
+                    """
 fitting_variables
     x 1.0 0.0 5.0
 """
-            ))
-        self.assertEqual(str(err.exception), "Fitting variables defined without defining a set of data to fit")
+                )
+            )
+        self.assertEqual(
+            str(err.exception),
+            "Fitting variables defined without defining a set of data to fit",
+        )
 
         # invalid variable range
         with self.assertRaises(ValueError) as err:
-            i4 = MuSpinInput(StringIO("""
+            MuSpinInput(
+                StringIO(
+                    """
 fitting_variables
     x 1.0 0.0 -5.0
 fitting_data
@@ -358,18 +434,24 @@ field
     2*x
 zeeman 1
     x x 0
-""".format(fname=tfile.name)
-            ))
-        self.assertEqual(str(err.exception),
-                "Variable x has invalid range: "
-                "(max value -5.0 cannot be less than or equal to min value 0.0)\n"
-                "Variable x has invalid starting value: "
-                "(starting value 1.0 cannot be greater than max value -5.0)"
+""".format(
+                        fname=tfile.name
+                    )
+                )
+            )
+        self.assertEqual(
+            str(err.exception),
+            "Variable x has invalid range: "
+            "(max value -5.0 cannot be less than or equal to min value 0.0)\n"
+            "Variable x has invalid starting value: "
+            "(starting value 1.0 cannot be greater than max value -5.0)",
         )
 
         # variable name clashes with constant
         with self.assertRaises(ValueError) as err:
-            i5 = MuSpinInput(StringIO("""
+            MuSpinInput(
+                StringIO(
+                    """
 fitting_variables
     MHz 1.0 0.0 5.0
 fitting_data
@@ -381,5 +463,10 @@ field
     2*x
 zeeman 1
     MHz 0 0
-"""))
-        self.assertEqual(str(err.exception), "Variable names {'MHz'} conflict with existing constants")
+"""
+                )
+            )
+        self.assertEqual(
+            str(err.exception),
+            "Variable names {'MHz'} conflict with existing constants",
+        )

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -3,7 +3,6 @@ import numpy as np
 from io import StringIO
 from tempfile import NamedTemporaryFile
 
-from muspinsim.input.larkeval import LarkExpression, LarkExpressionError, lark_tokenize
 from muspinsim.input.keyword import (
     MuSpinKeyword,
     MuSpinEvaluateKeyword,
@@ -15,126 +14,8 @@ from muspinsim.input import MuSpinInput
 
 
 class TestInput(unittest.TestCase):
-    def test_larkexpr(self):
-        """Lark expression unit test"""
 
         def double(x):
-            return 2 * x
-
-        larktests = [
-            # read expression
-            {"larkexpr": "3+2*6^2/9", "funcs": {}, "invalid": False, "out": 11},
-            # read function - double
-            {
-                "larkexpr": "double(2)",
-                "funcs": {"double": double},
-                "invalid": False,
-                "out": 4,
-            },
-            # read expression within function
-            {
-                "larkexpr": "double(3+2*6^2/9)",
-                "funcs": {"double": double},
-                "invalid": False,
-                "out": 22,
-            },
-            # read expression composed of multiple functions
-            {
-                "larkexpr": "double(3+2* 6^2/9) - double(2 *5)",
-                "funcs": {"double": double},
-                "invalid": False,
-                "out": 2,
-            },
-            # invalid function
-            {
-                "larkexpr": "notafunc(123)",
-                "funcs": {"double": double},
-                "invalid": True,
-                "out": "Invalid function: 'notafunc()', "
-                "valid functions are ['double()']",
-            },
-            # invalid expression
-            {
-                "larkexpr": "3*",
-                "funcs": {},
-                "invalid": True,
-                "out": "Invalid characters in LarkExpression: Unexpected token",
-            },
-            # empty expression
-            {"larkexpr": "", "funcs": {}, "invalid": True, "out": "Empty String"},
-        ]
-
-        for test in larktests:
-
-            if not test["invalid"]:
-                e1 = LarkExpression(test["larkexpr"], functions=test["funcs"])
-                self.assertTrue(e1.evaluate() == test["out"])
-            else:
-                with self.assertRaises(LarkExpressionError) as err:
-                    e1 = LarkExpression(test["larkexpr"], functions=test["funcs"])
-                self.assertTrue(test["out"] in str(err.exception))
-
-    def test_larkexpr_var(self):
-
-        # Simple expressions
-        e2 = LarkExpression("x+y+1", variables="xy")
-
-        self.assertEqual(e2.variables, {"x", "y"})
-        self.assertEqual(e2.evaluate(x=2, y=5), 8)
-
-        # Try using a function
-        def double(x):
-            return 2 * x
-
-        e3 = LarkExpression("double(x)", variables="x", functions={"double": double})
-
-        self.assertEqual(e3.variables, {"x"})
-        self.assertEqual(e3.functions, {"double"})
-        self.assertEqual(e3.evaluate(x=2), 4)
-
-        # lark expression does not contain variable given
-        with self.assertRaises(LarkExpressionError) as err:
-            e4 = LarkExpression("x+1", variables="y")
-        self.assertEqual(
-            str(err.exception),
-            "Invalid variable/constant: 'x', valid variables/constants are ['y']",
-        )
-
-        # value of variable not given when evaluating
-        with self.assertRaises(LarkExpressionError) as err:
-            e5 = LarkExpression("x+1", variables="x")
-            e5.evaluate()
-        self.assertEqual(
-            str(err.exception),
-            "Some necessary variable(s) {'x'} have not been defined "
-            "when evaluating LarkExpression",
-        )
-
-        # invalid variable value given when evaluating
-        with self.assertRaises(LarkExpressionError) as err:
-            e5 = LarkExpression("x+1", variables="x")
-            e5.evaluate(x=1, y=1)
-        self.assertEqual(
-            str(err.exception),
-            "Some invalid variable(s) {'y'} have been defined when "
-            "evaluating LarkExpression",
-        )
-
-    def test_tokenization(self):
-        tokens = lark_tokenize("3+0.4 2.3 sin(x) atan2(3, 4)")
-        lark_tokens = [
-            LarkExpression(
-                tk, variables="x", functions={"sin": np.sin, "atan2": np.arctan2}
-            )
-            for tk in tokens
-        ]
-
-        self.assertEqual(len(tokens), 4)
-        self.assertEqual(lark_tokens[0].evaluate(), 3.4)
-        self.assertEqual(lark_tokens[1].evaluate(), 2.3)
-        self.assertAlmostEqual(lark_tokens[2].evaluate(x=np.pi / 2.0), 1.0)
-        self.assertAlmostEqual(lark_tokens[3].evaluate(), np.arctan2(3.0, 4.0))
-
     def test_keyword(self):
 
         # Basic keyword

--- a/test/test_lark.py
+++ b/test/test_lark.py
@@ -8,129 +8,150 @@ def _double(x):
 
 
 class TestLark(unittest.TestCase):
-
     def _larkepxr_parse(self, test):
         """Lark expression unit test"""
         eval_vars = {k: v for k, v in test["vars"].items() if v is not None}
         if not test["invalid"]:
-            e1 = LarkExpression(test["expr"], functions=test["funcs"], variables=list(test["vars"].keys()))
+            e1 = LarkExpression(
+                test["expr"],
+                functions=test["funcs"],
+                variables=list(test["vars"].keys()),
+            )
             self.assertTrue(e1.evaluate(**eval_vars) == test["out"])
         else:
             with self.assertRaises(LarkExpressionError) as err:
-                e1 = LarkExpression(test["expr"], functions=test["funcs"], variables=list(test["vars"].keys()))
+                e1 = LarkExpression(
+                    test["expr"],
+                    functions=test["funcs"],
+                    variables=list(test["vars"].keys()),
+                )
                 e1.evaluate(**eval_vars)
 
             self.assertTrue(test["out"] in str(err.exception))
 
     def test_lark_expr(self):
-        self._larkepxr_parse({
-            "expr": "3+2*6^2/9",
-            "funcs": {},
-            "vars": {},
-            "invalid": False,
-            "out": 11
-        })
+        self._larkepxr_parse(
+            {"expr": "3+2*6^2/9", "funcs": {}, "vars": {}, "invalid": False, "out": 11}
+        )
 
     def test_lark_func(self):
 
-        self._larkepxr_parse({
-            "expr": "double(2)",
-            "funcs": {"double": _double},
-            "vars": {},
-            "invalid": False,
-            "out": 4,
-        })
+        self._larkepxr_parse(
+            {
+                "expr": "double(2)",
+                "funcs": {"double": _double},
+                "vars": {},
+                "invalid": False,
+                "out": 4,
+            }
+        )
 
     def test_lark_expr_in_func(self):
-        self._larkepxr_parse({
-            "expr": "double(3+2*6^2/9)",
-            "funcs": {"double": _double},
-            "vars": {},
-            "invalid": False,
-            "out": 22,
-        })
+        self._larkepxr_parse(
+            {
+                "expr": "double(3+2*6^2/9)",
+                "funcs": {"double": _double},
+                "vars": {},
+                "invalid": False,
+                "out": 22,
+            }
+        )
 
     def test_lark_multi_expr_in_func(self):
-        self._larkepxr_parse({
-            "expr": "double(3+2* 6^2/9) - double(2 *5)",
-            "funcs": {"double": _double},
-            "vars": {},
-            "invalid": False,
-            "out": 2,
-        })
+        self._larkepxr_parse(
+            {
+                "expr": "double(3+2* 6^2/9) - double(2 *5)",
+                "funcs": {"double": _double},
+                "vars": {},
+                "invalid": False,
+                "out": 2,
+            }
+        )
 
     def test_lark_invalid_func(self):
-        self._larkepxr_parse({
-            "expr": "notafunc(123)",
-            "funcs": {"double": _double},
-            "vars": {},
-            "invalid": True,
-            "out": "Invalid function: 'notafunc()', "
-                   "valid functions are ['double()']",
-        })
+        self._larkepxr_parse(
+            {
+                "expr": "notafunc(123)",
+                "funcs": {"double": _double},
+                "vars": {},
+                "invalid": True,
+                "out": "Invalid function: 'notafunc()', "
+                "valid functions are ['double()']",
+            }
+        )
 
     def test_lark_invalid_expr(self):
-        self._larkepxr_parse({
-            "expr": "3*",
-            "funcs": {},
-            "vars": {},
-            "invalid": True,
-            "out": "Invalid characters in LarkExpression: Unexpected token",
-        })
+        self._larkepxr_parse(
+            {
+                "expr": "3*",
+                "funcs": {},
+                "vars": {},
+                "invalid": True,
+                "out": "Invalid characters in LarkExpression: Unexpected token",
+            }
+        )
 
     def test_lark_empty(self):
-        self._larkepxr_parse({
-            "expr": "",
-            "funcs": {},
-            "vars": {},
-            "invalid": True,
-            "out": "Empty String"
-        })
+        self._larkepxr_parse(
+            {
+                "expr": "",
+                "funcs": {},
+                "vars": {},
+                "invalid": True,
+                "out": "Empty String",
+            }
+        )
 
     def test_lark_var(self):
-        self._larkepxr_parse({
-            "expr": "x+1",
-            "funcs": {},
-            "vars": {"x": 5},
-            "invalid": False,
-            "out": 6
-        })
+        self._larkepxr_parse(
+            {"expr": "x+1", "funcs": {}, "vars": {"x": 5}, "invalid": False, "out": 6}
+        )
 
     def test_lark_func_with_var(self):
-        self._larkepxr_parse({
-            "expr": "double(x)",
-            "funcs": {"double": _double},
-            "vars": {"x": 2},
-            "invalid": False,
-            "out": 4
-        })
+        self._larkepxr_parse(
+            {
+                "expr": "double(x)",
+                "funcs": {"double": _double},
+                "vars": {"x": 2},
+                "invalid": False,
+                "out": 4,
+            }
+        )
 
     def test_lark_multi_var(self):
-        self._larkepxr_parse({
-            "expr": "x+y+1",
-            "funcs": {},
-            "vars": {"x": 2, "y": 5},
-            "invalid": False,
-            "out": 8
-        })
+        self._larkepxr_parse(
+            {
+                "expr": "x+y+1",
+                "funcs": {},
+                "vars": {"x": 2, "y": 5},
+                "invalid": False,
+                "out": 8,
+            }
+        )
 
     def test_lark_vars_value_missing(self):
-        self._larkepxr_parse({
-            "expr": "x+1",
-            "funcs": {},
-            "vars": {"x": None},
-            "invalid": True,
-            "out": "Some necessary variable(s) {'x'} have not been defined when evaluating LarkExpression",
-        })
+        self._larkepxr_parse(
+            {
+                "expr": "x+1",
+                "funcs": {},
+                "vars": {"x": None},
+                "invalid": True,
+                "out": "Some necessary variable(s) {'x'} have not "
+                "been defined when evaluating LarkExpression",
+            }
+        )
 
     def test_lark_invalid_var(self):
-        self._larkepxr_parse({
-            "expr": "x+1",
-            "funcs": {},
-            "vars": {"y": 2},
-            "invalid": True,
-            "out": "Invalid variable/constant: 'x', valid variables/constants are ['y']",
-        })
+        self._larkepxr_parse(
+            {
+                "expr": "x+1",
+                "funcs": {},
+                "vars": {"y": 2},
+                "invalid": True,
+                "out": "Invalid variable/constant: 'x', "
+                "valid variables/constants are ['y']",
+            }
+        )
 
     def test_lark_evaluate_with_invalid_var(self):
         with self.assertRaises(LarkExpressionError) as err:
@@ -156,4 +177,3 @@ class TestLark(unittest.TestCase):
         self.assertEqual(lark_tokens[1].evaluate(), 2.3)
         self.assertAlmostEqual(lark_tokens[2].evaluate(x=np.pi / 2.0), 1.0)
         self.assertAlmostEqual(lark_tokens[3].evaluate(), np.arctan2(3.0, 4.0))
-

--- a/test/test_lark.py
+++ b/test/test_lark.py
@@ -1,0 +1,159 @@
+import unittest
+from muspinsim.input.larkeval import LarkExpression, LarkExpressionError, lark_tokenize
+import numpy as np
+
+
+def _double(x):
+    return x * 2
+
+
+class TestLark(unittest.TestCase):
+
+    def _larkepxr_parse(self, test):
+        """Lark expression unit test"""
+        eval_vars = {k: v for k, v in test["vars"].items() if v is not None}
+        if not test["invalid"]:
+            e1 = LarkExpression(test["expr"], functions=test["funcs"], variables=list(test["vars"].keys()))
+            self.assertTrue(e1.evaluate(**eval_vars) == test["out"])
+        else:
+            with self.assertRaises(LarkExpressionError) as err:
+                e1 = LarkExpression(test["expr"], functions=test["funcs"], variables=list(test["vars"].keys()))
+                e1.evaluate(**eval_vars)
+
+            self.assertTrue(test["out"] in str(err.exception))
+
+    def test_lark_expr(self):
+        self._larkepxr_parse({
+            "expr": "3+2*6^2/9",
+            "funcs": {},
+            "vars": {},
+            "invalid": False,
+            "out": 11
+        })
+
+    def test_lark_func(self):
+
+        self._larkepxr_parse({
+            "expr": "double(2)",
+            "funcs": {"double": _double},
+            "vars": {},
+            "invalid": False,
+            "out": 4,
+        })
+
+    def test_lark_expr_in_func(self):
+        self._larkepxr_parse({
+            "expr": "double(3+2*6^2/9)",
+            "funcs": {"double": _double},
+            "vars": {},
+            "invalid": False,
+            "out": 22,
+        })
+
+    def test_lark_multi_expr_in_func(self):
+        self._larkepxr_parse({
+            "expr": "double(3+2* 6^2/9) - double(2 *5)",
+            "funcs": {"double": _double},
+            "vars": {},
+            "invalid": False,
+            "out": 2,
+        })
+
+    def test_lark_invalid_func(self):
+        self._larkepxr_parse({
+            "expr": "notafunc(123)",
+            "funcs": {"double": _double},
+            "vars": {},
+            "invalid": True,
+            "out": "Invalid function: 'notafunc()', "
+                   "valid functions are ['double()']",
+        })
+
+    def test_lark_invalid_expr(self):
+        self._larkepxr_parse({
+            "expr": "3*",
+            "funcs": {},
+            "vars": {},
+            "invalid": True,
+            "out": "Invalid characters in LarkExpression: Unexpected token",
+        })
+
+    def test_lark_empty(self):
+        self._larkepxr_parse({
+            "expr": "",
+            "funcs": {},
+            "vars": {},
+            "invalid": True,
+            "out": "Empty String"
+        })
+
+    def test_lark_var(self):
+        self._larkepxr_parse({
+            "expr": "x+1",
+            "funcs": {},
+            "vars": {"x": 5},
+            "invalid": False,
+            "out": 6
+        })
+
+    def test_lark_func_with_var(self):
+        self._larkepxr_parse({
+            "expr": "double(x)",
+            "funcs": {"double": _double},
+            "vars": {"x": 2},
+            "invalid": False,
+            "out": 4
+        })
+
+    def test_lark_multi_var(self):
+        self._larkepxr_parse({
+            "expr": "x+y+1",
+            "funcs": {},
+            "vars": {"x": 2, "y": 5},
+            "invalid": False,
+            "out": 8
+        })
+
+    def test_lark_vars_value_missing(self):
+        self._larkepxr_parse({
+            "expr": "x+1",
+            "funcs": {},
+            "vars": {"x": None},
+            "invalid": True,
+            "out": "Some necessary variable(s) {'x'} have not been defined when evaluating LarkExpression",
+        })
+
+    def test_lark_invalid_var(self):
+        self._larkepxr_parse({
+            "expr": "x+1",
+            "funcs": {},
+            "vars": {"y": 2},
+            "invalid": True,
+            "out": "Invalid variable/constant: 'x', valid variables/constants are ['y']",
+        })
+
+    def test_lark_evaluate_with_invalid_var(self):
+        with self.assertRaises(LarkExpressionError) as err:
+            out = LarkExpression("x+1", variables="x")
+            out.evaluate(x=1, y=1)
+        self.assertEqual(
+            str(err.exception),
+            "Some invalid variable(s) {'y'} have been defined when "
+            "evaluating LarkExpression",
+        )
+
+    def test_tokenization(self):
+        tokens = lark_tokenize("3+0.4 2.3 sin(x) atan2(3, 4)")
+        lark_tokens = [
+            LarkExpression(
+                tk, variables="x", functions={"sin": np.sin, "atan2": np.arctan2}
+            )
+            for tk in tokens
+        ]
+
+        self.assertEqual(len(tokens), 4)
+        self.assertEqual(lark_tokens[0].evaluate(), 3.4)
+        self.assertEqual(lark_tokens[1].evaluate(), 2.3)
+        self.assertAlmostEqual(lark_tokens[2].evaluate(x=np.pi / 2.0), 1.0)
+        self.assertAlmostEqual(lark_tokens[3].evaluate(), np.arctan2(3.0, 4.0))
+


### PR DESCRIPTION
Some misc improvements to tests that I collected into a PR

mostly making sure error messages we expect to see in tests are the correct ones

Improvements to error messages when `validate_values()` method fails for MuSpinKeyword objects 

Added test case for `KWFittingVariables` where variable name clashes with constant