### PR TITLE
Add more command line arguments

### DIFF
--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -25,9 +25,7 @@ LOGFORMAT = "[%(levelname)s] [%(threadName)s] [%(asctime)s] %(message)s"
 
 
 def ensure_dir_path_exists(path_string):
-    if os.path.isdir(path_string):
-        return path_string
-    else:
+    if not os.path.isdir(path_string):
         try:
             os.makedirs(path_string)
         except OSError:
@@ -51,28 +49,30 @@ def main(use_mpi=False):
             "--fit-report-path",
             type=str,
             default=None,
-            help="""filepath to store fit report if fitting parameters given""",
+            help="filepath to store fit report if fitting parameters given",
         )
         parser.add_argument(
             "-l",
             "--log-path",
             type=str,
             default=None,
-            help="""filepath to store simulation logs """,
+            help="filepath to store simulation logs",
         )
         parser.add_argument(
             "-o",
             "--out-dir",
             type=str,
             default=None,
-            help="""folder to store the output .dat files""",
+            help="folder to store the output .dat files",
         )
         parser.add_argument(
             "input_file",
             type=ap.FileType("r"),
             default=None,
-            help="""filepath to muspinsim specially formatted text
-            file specifying simulation input parameters.""",
+            help="path to file specifying simulation input parameters. "
+            "For formatting and keywords, see https://"
+            "muon-spectroscopy-computational-project.github.io"
+            "/muspinsim/input/.",
         )
         args = parser.parse_args()
         inp_filepath = args.input_file.name
@@ -88,17 +88,14 @@ def main(use_mpi=False):
         # Open logfile
         logfile = os.path.join(inp_dir, inp_file_name + ".log")
         if args.log_path:
-
             try:
+                # check if directory exists, if not create it
                 log_path = ensure_dir_path_exists(os.path.dirname(args.log_path))
                 log_fname = os.path.basename(args.log_path)
-            # in case it was just a filename given
-            # - default directory is input dir
             except NotADirectoryError:
+                # if log_path was just a filename use inp_dir as a default
                 log_path = inp_dir
                 log_fname = args.log_path
-
-            # check if directory exists, if not create it
             logfile = os.path.join(log_path, log_fname)
 
         logging.basicConfig(
@@ -148,13 +145,12 @@ def main(use_mpi=False):
             rep_fname = "{0}_fit_report.txt".format(inp_file_name)
             if args.fit_report_path:
                 try:
+                    # check if directory exists, if not create it
                     ensure_dir_path_exists(os.path.dirname(args.fit_report_path))
                     rep_fname = os.path.basename(args.fit_report_path)
                     rep_dname = os.path.dirname(args.fit_report_path)
-
-                # in case it was just a filename given
-                # - default directory is input dir
                 except NotADirectoryError:
+                    # if fit_report_path was just a filename use inp_dir as a default
                     rep_fname = args.fit_report_path
                     rep_dname = inp_dir
 

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -91,9 +91,12 @@ def main(use_mpi=False):
 
             try:
                 log_path = ensure_dir_path_exists(os.path.dirname(args.log_path))
-            # in case it was just a filename given - default directory is input directory
+            # in case it was just a filename given
+            # - default directory is input dir
             except NotADirectoryError:
-                log_path = ensure_dir_path_exists(os.path.dirname("{0}/{1}".format(inp_dir, args.log_path)))
+                log_path = ensure_dir_path_exists(
+                    os.path.dirname("{0}/{1}".format(inp_dir, args.log_path))
+                )
 
             # check if directory exists, if not create it
             logfile = "{0}/{1}".format(
@@ -147,9 +150,7 @@ def main(use_mpi=False):
             rep_fname = "{0}_fit_report.txt".format(inp_file_name)
             if args.fit_report_path:
                 try:
-                    ensure_dir_path_exists(
-                        os.path.dirname(args.fit_report_path)
-                    )
+                    ensure_dir_path_exists(os.path.dirname(args.fit_report_path))
                     rep_fname = os.path.basename(args.fit_report_path)
                     rep_dname = os.path.dirname(args.fit_report_path)
 

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -76,20 +76,20 @@ def main(use_mpi=False):
         )
         args = parser.parse_args()
         inp_filepath = args.input_file.name
+        inp_dir = "{0}.log".format(os.path.splitext(inp_filepath)[0])
 
         fs = open(inp_filepath)
         infile = MuSpinInput(fs)
         is_fitting = len(infile.variables) > 0
 
         # Open logfile
+        logfile = inp_dir
         if args.log_path:
             # check if directory exists, if not create it
             logfile = "{0}/{1}".format(
                 check_dir_path(os.path.dirname(args.log_path)),
                 os.path.basename(args.log_path),
             )
-        else:
-            logfile = "{0}.log".format(os.path.splitext(inp_filepath)[0])
 
         logging.basicConfig(
             filename=logfile,
@@ -119,7 +119,7 @@ def main(use_mpi=False):
     if args.out_dir:
         out_path = check_dir_path(args.out_dir)
     else:
-        out_path = "./"
+        out_path = inp_dir
 
     if not is_fitting:
         # No fitting
@@ -134,11 +134,13 @@ def main(use_mpi=False):
         fitter.run(name=None, path=out_path)
 
         if mpi.is_root:
+            rep_path = inp_dir
+            rep_fname = None
             if args.fitreport_path:
                 rep_path = check_dir_path(os.path.dirname(args.fitreport_path))
+                # default to creating it with outputs
                 rep_fname = os.path.basename(args.fitreport_path)
-            else:
-                rep_path = "./"
+
             fitter.write_report(fname=rep_fname, path=rep_path)
 
     if mpi.is_root:

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -115,21 +115,22 @@ def main(use_mpi=False):
 
     is_fitting = mpi.broadcast(is_fitting)
 
+    if args.out_dir:
+        out_path = check_dir_path(args.out_dir)
+    else:
+        out_path = "./"
+
     if not is_fitting:
         # No fitting
         runner = ExperimentRunner(infile, {})
         runner.run()
 
         if mpi.is_root:
-            if args.out_dir:
-                out_path = check_dir_path(args.out_dir)
-            else:
-                out_path = "./"
             # Output
             runner.config.save_output(name=None, path=out_path)
     else:
         fitter = FittingRunner(infile)
-        fitter.run()
+        fitter.run(name=None, path=out_path)
 
         if mpi.is_root:
             if args.fitreport_path:

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -62,7 +62,7 @@ def main(use_mpi=False):
         )
         parser.add_argument(
             "-f",
-            "--fitreport-path",
+            "--fit-report-path",
             type=str,
             default=None,
             help="""filepath to store fit report if fitting parameters given""",
@@ -135,10 +135,10 @@ def main(use_mpi=False):
         if mpi.is_root:
             rep_path = inp_dir
             rep_fname = None
-            if args.fitreport_path:
+            if args.fit_report_path:
                 rep_path = ensure_dir_path_exists(os.path.dirname(args.fit_report_path))
                 # default to creating it with outputs
-                rep_fname = os.path.basename(args.fitreport_path)
+                rep_fname = os.path.basename(args.fit_report_path)
 
             fitter.write_report(fname=rep_fname, path=rep_path)
 

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -86,7 +86,7 @@ def main(use_mpi=False):
         is_fitting = len(infile.variables) > 0
 
         # Open logfile
-        logfile = "{0}/{1}.log".format(inp_dir, inp_file_name)
+        logfile = os.path.join(inp_dir, inp_file_name + ".log")
         if args.log_path:
 
             try:
@@ -94,15 +94,10 @@ def main(use_mpi=False):
             # in case it was just a filename given
             # - default directory is input dir
             except NotADirectoryError:
-                log_path = ensure_dir_path_exists(
-                    os.path.dirname("{0}/{1}".format(inp_dir, args.log_path))
-                )
+                log_path = inp_dir
 
             # check if directory exists, if not create it
-            logfile = "{0}/{1}".format(
-                ensure_dir_path_exists(os.path.dirname(log_path)),
-                os.path.basename(log_path),
-            )
+            logfile = os.path.join(log_path, os.path.basename(args.log_path))
 
         logging.basicConfig(
             filename=logfile,
@@ -160,7 +155,6 @@ def main(use_mpi=False):
                     rep_fname = args.fit_report_path
                     rep_dname = inp_dir
 
-                # default to creating it with outputs
             fitter.write_report(fname=rep_fname, path=rep_dname)
 
     if mpi.is_root:

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -47,11 +47,11 @@ def main(use_mpi=False):
             "spin dynamics calculations for muon science experiments"
         )
         parser.add_argument(
-            "-o",
-            "--out-dir",
+            "-f",
+            "--fit-report-path",
             type=str,
             default=None,
-            help="""folder to store the output .dat files""",
+            help="""filepath to store fit report if fitting parameters given""",
         )
         parser.add_argument(
             "-l",
@@ -61,11 +61,11 @@ def main(use_mpi=False):
             help="""filepath to store simulation logs """,
         )
         parser.add_argument(
-            "-f",
-            "--fit-report-path",
+            "-o",
+            "--out-dir",
             type=str,
             default=None,
-            help="""filepath to store fit report if fitting parameters given""",
+            help="""folder to store the output .dat files""",
         )
         parser.add_argument(
             "input_file",

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -24,6 +24,16 @@ from muspinsim.fitting import FittingRunner
 LOGFORMAT = "[%(levelname)s] [%(threadName)s] [%(asctime)s] %(message)s"
 
 
+def check_dir_path(string):
+    if os.path.isdir(string):
+        return string
+    else:
+        try:
+            os.makedirs(string)
+        except:
+            raise NotADirectoryError(string)
+    return string
+
 def main(use_mpi=False):
 
     if use_mpi:
@@ -32,6 +42,12 @@ def main(use_mpi=False):
     if mpi.is_root:
         # Entry point for script
         parser = ap.ArgumentParser(description='Muspinsim arguments')
+        parser.add_argument(
+            '-o', '--out-dir',
+            type=str,
+            default=None,
+            help="""destination folder to store output .dat files"""
+        )
         parser.add_argument(
             "input_file",
             type=ap.FileType('r'),
@@ -78,8 +94,12 @@ def main(use_mpi=False):
         runner.run()
 
         if mpi.is_root:
+            if args.out_dir:
+                out_path = check_dir_path(args.out_dir)
+            else:
+                out_path = "./"
             # Output
-            runner.config.save_output()
+            runner.config.save_output(name=None, path=out_path)
     else:
         fitter = FittingRunner(infile)
         fitter.run()

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -55,6 +55,12 @@ def main(use_mpi=False):
             help="""set log output path"""
         )
         parser.add_argument(
+            '-f', '--fitreport-path',
+            type=str,
+            default=None,
+            help="""set fit report output path"""
+        )
+        parser.add_argument(
             "input_file",
             type=ap.FileType('r'),
             default=None,
@@ -119,7 +125,12 @@ def main(use_mpi=False):
         fitter.run()
 
         if mpi.is_root:
-            fitter.write_report()
+            if args.fitreport_path:
+                rep_path = check_dir_path(os.path.dirname(args.fitreport_path))
+                rep_fname = os.path.basename(args.fitreport_path)
+            else:
+                rep_path = "./"
+            fitter.write_report(fname=rep_fname, path=rep_path)
 
     if mpi.is_root:
         tend = datetime.now()

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -105,6 +105,7 @@ def main(use_mpi=False):
             level=logging.INFO,
             format=LOGFORMAT,
             datefmt="%Y-%m-%d %H:%M:%S",
+            force=True,
         )
 
         logging.info(

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -36,8 +36,7 @@ def main(use_mpi=False):
             "input_file",
             type=str,
             default=None,
-            help="""YAML
-                            formatted file with input parameters.""",
+            help="""muspinsim formatted file with input parameters.""",
         )
         args = parser.parse_args()
 

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -30,9 +30,10 @@ def check_dir_path(string):
     else:
         try:
             os.makedirs(string)
-        except:
+        except OSError:
             raise NotADirectoryError(string)
     return string
+
 
 def main(use_mpi=False):
 
@@ -41,28 +42,27 @@ def main(use_mpi=False):
 
     if mpi.is_root:
         # Entry point for script
-        parser = ap.ArgumentParser(description='Muspinsim arguments')
+        parser = ap.ArgumentParser(description="Muspinsim arguments")
         parser.add_argument(
-            '-o', '--out-dir',
+            "-o",
+            "--out-dir",
             type=str,
             default=None,
-            help="""destination folder to store output .dat files"""
+            help="""destination folder to store output .dat files""",
         )
         parser.add_argument(
-            '-l', '--log-path',
-            type=str,
-            default=None,
-            help="""set log output path"""
+            "-l", "--log-path", type=str, default=None, help="""set log output path"""
         )
         parser.add_argument(
-            '-f', '--fitreport-path',
+            "-f",
+            "--fitreport-path",
             type=str,
             default=None,
-            help="""set fit report output path"""
+            help="""set fit report output path""",
         )
         parser.add_argument(
             "input_file",
-            type=ap.FileType('r'),
+            type=ap.FileType("r"),
             default=None,
             help="""muspinsim formatted file with input parameters.""",
         )
@@ -76,9 +76,9 @@ def main(use_mpi=False):
         # Open logfile
         if args.log_path:
             # check if directory exists, if not create it
-            logfile = '{0}/{1}'.format(
+            logfile = "{0}/{1}".format(
                 check_dir_path(os.path.dirname(args.log_path)),
-                os.path.basename(args.log_path)
+                os.path.basename(args.log_path),
             )
         else:
             logfile = "{0}.log".format(os.path.splitext(inp_filepath)[0])

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -49,6 +49,12 @@ def main(use_mpi=False):
             help="""destination folder to store output .dat files"""
         )
         parser.add_argument(
+            '-l', '--log-path',
+            type=str,
+            default=None,
+            help="""set log output path"""
+        )
+        parser.add_argument(
             "input_file",
             type=ap.FileType('r'),
             default=None,
@@ -62,7 +68,15 @@ def main(use_mpi=False):
         is_fitting = len(infile.variables) > 0
 
         # Open logfile
-        logfile = "{0}.log".format(os.path.splitext(args.input_file)[0])
+        if args.log_path:
+            # check if directory exists, if not create it
+            logfile = '{0}/{1}'.format(
+                check_dir_path(os.path.dirname(args.log_path)),
+                os.path.basename(args.log_path)
+            )
+        else:
+            logfile = "{0}.log".format(os.path.splitext(inp_filepath)[0])
+
         logging.basicConfig(
             filename=logfile,
             filemode="w",

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -165,6 +165,8 @@ def main(use_mpi=False):
         simtime = (tend - tstart).total_seconds()
         logging.info("Simulation completed in " "{0:.3f} seconds".format(simtime))
 
+    logging.shutdown()
+
 
 def main_mpi():
     main(use_mpi=True)

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -24,15 +24,15 @@ from muspinsim.fitting import FittingRunner
 LOGFORMAT = "[%(levelname)s] [%(threadName)s] [%(asctime)s] %(message)s"
 
 
-def check_dir_path(string):
-    if os.path.isdir(string):
-        return string
+def ensure_dir_path_exists(path_string):
+    if os.path.isdir(path_string):
+        return path_string
     else:
         try:
-            os.makedirs(string)
+            os.makedirs(path_string)
         except OSError:
-            raise NotADirectoryError(string)
-    return string
+            raise NotADirectoryError(path_string)
+    return path_string
 
 
 def main(use_mpi=False):
@@ -87,7 +87,7 @@ def main(use_mpi=False):
         if args.log_path:
             # check if directory exists, if not create it
             logfile = "{0}/{1}".format(
-                check_dir_path(os.path.dirname(args.log_path)),
+                ensure_dir_path_exists(os.path.dirname(args.log_path)),
                 os.path.basename(args.log_path),
             )
 
@@ -116,10 +116,9 @@ def main(use_mpi=False):
 
     is_fitting = mpi.broadcast(is_fitting)
 
+    out_path = inp_dir
     if args.out_dir:
-        out_path = check_dir_path(args.out_dir)
-    else:
-        out_path = inp_dir
+        out_path = ensure_dir_path_exists(args.out_dir)
 
     if not is_fitting:
         # No fitting
@@ -137,7 +136,7 @@ def main(use_mpi=False):
             rep_path = inp_dir
             rep_fname = None
             if args.fitreport_path:
-                rep_path = check_dir_path(os.path.dirname(args.fitreport_path))
+                rep_path = ensure_dir_path_exists(os.path.dirname(args.fit_report_path))
                 # default to creating it with outputs
                 rep_fname = os.path.basename(args.fitreport_path)
 

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -42,29 +42,36 @@ def main(use_mpi=False):
 
     if mpi.is_root:
         # Entry point for script
-        parser = ap.ArgumentParser(description="Muspinsim arguments")
+        parser = ap.ArgumentParser(
+            description="Muspinsim - A program designed to carry out "
+            "spin dynamics calculations for muon science experiments"
+        )
         parser.add_argument(
             "-o",
             "--out-dir",
             type=str,
             default=None,
-            help="""destination folder to store output .dat files""",
+            help="""folder to store the output .dat files""",
         )
         parser.add_argument(
-            "-l", "--log-path", type=str, default=None, help="""set log output path"""
+            "-l",
+            "--log-path",
+            type=str,
+            default=None,
+            help="""filepath to store simulation logs """,
         )
         parser.add_argument(
             "-f",
             "--fitreport-path",
             type=str,
             default=None,
-            help="""set fit report output path""",
+            help="""filepath to store fit report if fitting parameters given""",
         )
         parser.add_argument(
             "input_file",
             type=ap.FileType("r"),
             default=None,
-            help="""muspinsim formatted file with input parameters.""",
+            help="""filepath to muspinsim specially formatted text file specifying simulation input parameters.""",
         )
         args = parser.parse_args()
         inp_filepath = args.input_file.name

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -31,16 +31,17 @@ def main(use_mpi=False):
 
     if mpi.is_root:
         # Entry point for script
-        parser = ap.ArgumentParser()
+        parser = ap.ArgumentParser(description='Muspinsim arguments')
         parser.add_argument(
             "input_file",
-            type=str,
+            type=ap.FileType('r'),
             default=None,
             help="""muspinsim formatted file with input parameters.""",
         )
         args = parser.parse_args()
+        inp_filepath = args.input_file.name
 
-        fs = open(args.input_file)
+        fs = open(inp_filepath)
         infile = MuSpinInput(fs)
         is_fitting = len(infile.variables) > 0
 
@@ -55,7 +56,7 @@ def main(use_mpi=False):
         )
 
         logging.info(
-            "Launching MuSpinSim calculation " "from file: {0}".format(args.input_file)
+            "Launching MuSpinSim calculation " "from file: {0}".format(inp_filepath)
         )
 
         if is_fitting:

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -76,14 +76,17 @@ def main(use_mpi=False):
         )
         args = parser.parse_args()
         inp_filepath = args.input_file.name
-        inp_dir = "{0}.log".format(os.path.splitext(inp_filepath)[0])
+
+        # get input file name and directory - to be used as defaults
+        inp_file_name = os.path.basename(inp_filepath).split(".")[0]
+        inp_dir = os.path.dirname(inp_filepath)
 
         fs = open(inp_filepath)
         infile = MuSpinInput(fs)
         is_fitting = len(infile.variables) > 0
 
         # Open logfile
-        logfile = inp_dir
+        logfile = "{0}/{1}.log".format(inp_dir, inp_file_name)
         if args.log_path:
             # check if directory exists, if not create it
             logfile = "{0}/{1}".format(
@@ -134,11 +137,11 @@ def main(use_mpi=False):
 
         if mpi.is_root:
             rep_path = inp_dir
-            rep_fname = None
+            rep_fname = "{0}_fit_report.txt".format(inp_file_name)
             if args.fit_report_path:
                 rep_path = ensure_dir_path_exists(os.path.dirname(args.fit_report_path))
                 # default to creating it with outputs
-                rep_fname = os.path.basename(args.fit_report_path)
+                rep_fname = os.path.basename(rep_path)
 
             fitter.write_report(fname=rep_fname, path=rep_path)
 

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -91,13 +91,15 @@ def main(use_mpi=False):
 
             try:
                 log_path = ensure_dir_path_exists(os.path.dirname(args.log_path))
+                log_fname = os.path.basename(args.log_path)
             # in case it was just a filename given
             # - default directory is input dir
             except NotADirectoryError:
                 log_path = inp_dir
+                log_fname = args.log_path
 
             # check if directory exists, if not create it
-            logfile = os.path.join(log_path, os.path.basename(args.log_path))
+            logfile = os.path.join(log_path, log_fname)
 
         logging.basicConfig(
             filename=logfile,

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -71,7 +71,8 @@ def main(use_mpi=False):
             "input_file",
             type=ap.FileType("r"),
             default=None,
-            help="""filepath to muspinsim specially formatted text file specifying simulation input parameters.""",
+            help="""filepath to muspinsim specially formatted text
+            file specifying simulation input parameters.""",
         )
         args = parser.parse_args()
         inp_filepath = args.input_file.name

--- a/muspinsim/fitting.py
+++ b/muspinsim/fitting.py
@@ -54,7 +54,7 @@ class FittingRunner(object):
         self._done = False
         self._sol = None
 
-    def run(self):
+    def run(self, name=None, path="."):
         """Run a fitting calculation using Scipy, and returns the solution
 
         Returns:
@@ -82,7 +82,7 @@ class FittingRunner(object):
             mpi.broadcast_object(self, ["_sol"])
 
             # And now save the last result
-            self._runner.config.save_output()
+            self._runner.config.save_output(name=name, path=path)
         else:
             while not self._done:
                 self._targfun(self._x)

--- a/muspinsim/fitting.py
+++ b/muspinsim/fitting.py
@@ -130,7 +130,7 @@ class FittingRunner(object):
             config = MuSpinConfig(self._input.evaluate(**variables))
 
             if fname is None:
-                fname = config.name + "_fitreport.txt"
+                fname = config.name + "_fit_report.txt"
 
             with open(os.path.join(path, fname), "w") as f:
                 f.write("Fitting process for {0} completed\n".format(config.name))

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -89,6 +89,36 @@ dissipation 1
             self.assertTrue(os.path.exists('{0}/test_fitting.dat'.format(tmp_dir)))
             self.assertTrue(os.path.exists('{0}/fitting_default_args_fit_report.txt'.format(tmp_dir)))
 
+    def test_main_filenames_as_input(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cmd_args = [
+                '-l', 'new_test.log',
+                '-f', 'new_fit_report.txt'
+            ]
+            inp_file_path = os.path.join(tmp_dir, 'fitting_default_args.in')
+            run_experiment("""
+name
+    test_fitting
+spins
+    mu
+field
+    1.0/muon_gyr
+fitting_data
+    0 1
+    1 2
+fitting_variables
+    g 0.1 0.0 inf
+dissipation 1
+    g
+""",
+                           inp_file_path,
+                           cmd_args
+                           )
+
+            # self.assertTrue(os.path.exists("{0}/fitting_default_args.log".format(tmp_dir)))
+            self.assertTrue(os.path.exists('{0}/test_fitting.dat'.format(tmp_dir)))
+            self.assertTrue(os.path.exists('{0}/new_fit_report.txt'.format(tmp_dir)))
+
     def test_main_fitting_custom_args(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with tempfile.TemporaryDirectory() as out_tmp_dir:

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -1,0 +1,122 @@
+import sys
+import os
+import unittest
+import tempfile
+
+from muspinsim.__main__ import main
+
+
+def set_sys_argv(vals):
+    sys.argv[1:] = vals
+
+
+def run_experiment(inp_string, inp_file_path, cmd_args):
+    with open(inp_file_path, "w") as f:
+        f.write(inp_string)
+    set_sys_argv([inp_file_path] + cmd_args)
+    main()
+
+
+class TestCommandLineArgs(unittest.TestCase):
+
+    def test_main_default_args(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cmd_args = []
+            inp_file_path = os.path.join(tmp_dir, 'custom_args.in')
+            run_experiment("""
+name
+    test_1
+spins
+    mu H
+zeeman 1
+    1 0 0
+""",
+                           inp_file_path,
+                           cmd_args
+                           )
+
+            # self.assertTrue(os.path.exists("{0}/custom_args.log".format(tmp_dir)))
+            self.assertTrue(os.path.exists("{0}/test_1.dat".format(tmp_dir)))
+
+    def test_main_custom_args(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with tempfile.TemporaryDirectory() as out_tmp_dir:
+                cmd_args = [
+                    '-o', '{0}'.format(out_tmp_dir),
+                    '-l', '{0}/new_test.log'.format(out_tmp_dir),
+                ]
+                inp_file_path = os.path.join(tmp_dir, 'custom_args.in')
+                run_experiment("""
+name
+    test_2
+spins
+    mu H
+zeeman 1
+    1 0 0
+""",
+                               inp_file_path,
+                               cmd_args
+                               )
+
+                # self.assertTrue(os.path.exists("{0}/new_test.log".format(out_tmp_dir)))
+                self.assertTrue(os.path.exists('{0}/test_2.dat'.format(out_tmp_dir)))
+
+    def test_main_fitting_default_args(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cmd_args = [
+            ]
+            inp_file_path = os.path.join(tmp_dir, 'fitting_default_args.in')
+            run_experiment("""
+name
+    test_fitting
+spins
+    mu
+field
+    1.0/muon_gyr
+fitting_data
+    0 1
+    1 2
+fitting_variables
+    g 0.1 0.0 inf
+dissipation 1
+    g
+""",
+                           inp_file_path,
+                           cmd_args
+                           )
+
+            # self.assertTrue(os.path.exists("{0}/fitting_default_args.log".format(tmp_dir)))
+            self.assertTrue(os.path.exists('{0}/test_fitting.dat'.format(tmp_dir)))
+            self.assertTrue(os.path.exists('{0}/fitting_default_args_fit_report.txt'.format(tmp_dir)))
+
+    def test_main_fitting_custom_args(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with tempfile.TemporaryDirectory() as out_tmp_dir:
+                cmd_args = [
+                    '-o', '{0}'.format(out_tmp_dir),
+                    '-l', '{0}/new_test.log'.format(out_tmp_dir),
+                    '-f', '{0}/new_fit_report.txt'.format(out_tmp_dir)
+                ]
+                inp_file_path = os.path.join(tmp_dir, 'test.in')
+                run_experiment("""
+name
+    test_fitting
+spins
+    mu
+field
+    1.0/muon_gyr
+fitting_data
+    0 1
+    1 2
+fitting_variables
+    g 0.1 0.0 inf
+dissipation 1
+    g
+""",
+                               inp_file_path,
+                               cmd_args
+                               )
+
+                # self.assertTrue(os.path.exists("{0}/new_test.log".format(out_tmp_dir)))
+                self.assertTrue(os.path.exists('{0}/test_fitting.dat'.format(out_tmp_dir)))
+                self.assertTrue(os.path.exists('{0}/new_fit_report.txt'.format(out_tmp_dir)))

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -18,12 +18,12 @@ def run_experiment(inp_string, inp_file_path, cmd_args):
 
 
 class TestCommandLineArgs(unittest.TestCase):
-
     def test_main_default_args(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             cmd_args = []
-            inp_file_path = os.path.join(tmp_dir, 'custom_args.in')
-            run_experiment("""
+            inp_file_path = os.path.join(tmp_dir, "custom_args.in")
+            run_experiment(
+                """
 name
     test_1
 spins
@@ -31,9 +31,9 @@ spins
 zeeman 1
     1 0 0
 """,
-                           inp_file_path,
-                           cmd_args
-                           )
+                inp_file_path,
+                cmd_args,
+            )
 
             # self.assertTrue(os.path.exists("{0}/custom_args.log".format(tmp_dir)))
             self.assertTrue(os.path.exists("{0}/test_1.dat".format(tmp_dir)))
@@ -42,11 +42,14 @@ zeeman 1
         with tempfile.TemporaryDirectory() as tmp_dir:
             with tempfile.TemporaryDirectory() as out_tmp_dir:
                 cmd_args = [
-                    '-o', '{0}'.format(out_tmp_dir),
-                    '-l', '{0}/new_test.log'.format(out_tmp_dir),
+                    "-o",
+                    "{0}".format(out_tmp_dir),
+                    "-l",
+                    "{0}/new_test.log".format(out_tmp_dir),
                 ]
-                inp_file_path = os.path.join(tmp_dir, 'custom_args.in')
-                run_experiment("""
+                inp_file_path = os.path.join(tmp_dir, "custom_args.in")
+                run_experiment(
+                    """
 name
     test_2
 spins
@@ -54,19 +57,19 @@ spins
 zeeman 1
     1 0 0
 """,
-                               inp_file_path,
-                               cmd_args
-                               )
+                    inp_file_path,
+                    cmd_args,
+                )
 
                 # self.assertTrue(os.path.exists("{0}/new_test.log".format(out_tmp_dir)))
-                self.assertTrue(os.path.exists('{0}/test_2.dat'.format(out_tmp_dir)))
+                self.assertTrue(os.path.exists("{0}/test_2.dat".format(out_tmp_dir)))
 
     def test_main_fitting_default_args(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            cmd_args = [
-            ]
-            inp_file_path = os.path.join(tmp_dir, 'fitting_default_args.in')
-            run_experiment("""
+            cmd_args = []
+            inp_file_path = os.path.join(tmp_dir, "fitting_default_args.in")
+            run_experiment(
+                """
 name
     test_fitting
 spins
@@ -81,22 +84,24 @@ fitting_variables
 dissipation 1
     g
 """,
-                           inp_file_path,
-                           cmd_args
-                           )
+                inp_file_path,
+                cmd_args,
+            )
 
             # self.assertTrue(os.path.exists("{0}/fitting_default_args.log".format(tmp_dir)))
-            self.assertTrue(os.path.exists('{0}/test_fitting.dat'.format(tmp_dir)))
-            self.assertTrue(os.path.exists('{0}/fitting_default_args_fit_report.txt'.format(tmp_dir)))
+            self.assertTrue(os.path.exists("{0}/test_fitting.dat".format(tmp_dir)))
+            self.assertTrue(
+                os.path.exists(
+                    "{0}/fitting_default_args_fit_report.txt".format(tmp_dir)
+                )
+            )
 
     def test_main_filenames_as_input(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            cmd_args = [
-                '-l', 'new_test.log',
-                '-f', 'new_fit_report.txt'
-            ]
-            inp_file_path = os.path.join(tmp_dir, 'fitting_default_args.in')
-            run_experiment("""
+            cmd_args = ["-l", "new_test.log", "-f", "new_fit_report.txt"]
+            inp_file_path = os.path.join(tmp_dir, "fitting_default_args.in")
+            run_experiment(
+                """
 name
     test_fitting
 spins
@@ -111,24 +116,28 @@ fitting_variables
 dissipation 1
     g
 """,
-                           inp_file_path,
-                           cmd_args
-                           )
+                inp_file_path,
+                cmd_args,
+            )
 
             # self.assertTrue(os.path.exists("{0}/fitting_default_args.log".format(tmp_dir)))
-            self.assertTrue(os.path.exists('{0}/test_fitting.dat'.format(tmp_dir)))
-            self.assertTrue(os.path.exists('{0}/new_fit_report.txt'.format(tmp_dir)))
+            self.assertTrue(os.path.exists("{0}/test_fitting.dat".format(tmp_dir)))
+            self.assertTrue(os.path.exists("{0}/new_fit_report.txt".format(tmp_dir)))
 
     def test_main_fitting_custom_args(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with tempfile.TemporaryDirectory() as out_tmp_dir:
                 cmd_args = [
-                    '-o', '{0}'.format(out_tmp_dir),
-                    '-l', '{0}/new_test.log'.format(out_tmp_dir),
-                    '-f', '{0}/new_fit_report.txt'.format(out_tmp_dir)
+                    "-o",
+                    "{0}".format(out_tmp_dir),
+                    "-l",
+                    "{0}/new_test.log".format(out_tmp_dir),
+                    "-f",
+                    "{0}/new_fit_report.txt".format(out_tmp_dir),
                 ]
-                inp_file_path = os.path.join(tmp_dir, 'test.in')
-                run_experiment("""
+                inp_file_path = os.path.join(tmp_dir, "test.in")
+                run_experiment(
+                    """
 name
     test_fitting
 spins
@@ -143,10 +152,14 @@ fitting_variables
 dissipation 1
     g
 """,
-                               inp_file_path,
-                               cmd_args
-                               )
+                    inp_file_path,
+                    cmd_args,
+                )
 
                 # self.assertTrue(os.path.exists("{0}/new_test.log".format(out_tmp_dir)))
-                self.assertTrue(os.path.exists('{0}/test_fitting.dat'.format(out_tmp_dir)))
-                self.assertTrue(os.path.exists('{0}/new_fit_report.txt'.format(out_tmp_dir)))
+                self.assertTrue(
+                    os.path.exists("{0}/test_fitting.dat".format(out_tmp_dir))
+                )
+                self.assertTrue(
+                    os.path.exists("{0}/new_fit_report.txt".format(out_tmp_dir))
+                )

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -35,7 +35,7 @@ zeeman 1
                 cmd_args,
             )
 
-            # self.assertTrue(os.path.exists(os.path.join(out_tmp_dir, 'custom_args.log')))
+            self.assertTrue(os.path.exists(os.path.join(tmp_dir, "custom_args.log")))
             self.assertTrue(os.path.exists("{0}/test_1.dat".format(tmp_dir)))
 
     def test_main_custom_args(self):
@@ -61,7 +61,9 @@ zeeman 1
                     cmd_args,
                 )
 
-                # self.assertTrue(os.path.exists(os.path.join(out_tmp_dir, 'new_test.log')))
+                self.assertTrue(
+                    os.path.exists(os.path.join(out_tmp_dir, "new_test.log"))
+                )
                 self.assertTrue(os.path.exists(os.path.join(out_tmp_dir, "test_2.dat")))
 
     def test_main_fitting_default_args(self):
@@ -88,7 +90,9 @@ dissipation 1
                 cmd_args,
             )
 
-            # self.assertTrue(os.path.exists(os.path.join(tmp_dir, 'fitting_default_args.log')))
+            self.assertTrue(
+                os.path.exists(os.path.join(tmp_dir, "fitting_default_args.log"))
+            )
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, "test_fitting.dat")))
             self.assertTrue(
                 os.path.exists(
@@ -120,7 +124,7 @@ dissipation 1
                 cmd_args,
             )
 
-            # self.assertTrue(os.path.exists("{0}/fitting_default_args.log".format(tmp_dir)))
+            self.assertTrue(os.path.exists("{0}/new_test.log".format(tmp_dir)))
             self.assertTrue(os.path.exists("{0}/test_fitting.dat".format(tmp_dir)))
             self.assertTrue(os.path.exists("{0}/new_fit_report.txt".format(tmp_dir)))
 
@@ -156,7 +160,9 @@ dissipation 1
                     cmd_args,
                 )
 
-                # self.assertTrue(os.path.exists(os.path.join(out_tmp_dir, 'new_test.log')))
+                self.assertTrue(
+                    os.path.exists(os.path.join(out_tmp_dir, "new_test.log"))
+                )
                 self.assertTrue(
                     os.path.exists(os.path.join(out_tmp_dir, "test_fitting.dat"))
                 )

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -2,6 +2,7 @@ import sys
 import os
 import unittest
 import tempfile
+import logging
 
 from muspinsim.__main__ import main
 
@@ -18,6 +19,13 @@ def run_experiment(inp_string, inp_file_path, cmd_args):
 
 
 class TestCommandLineArgs(unittest.TestCase):
+    @classmethod
+    def tearDownClass(self):
+        # The tests in this class setup the logger to use a temporary folder but for
+        # other tests that run afterwards this may no longer exist so revert to the
+        # default again and print to stdout to avoid FileNotFound errors
+        logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, force=True)
+
     def test_main_default_args(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             cmd_args = []

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -35,7 +35,7 @@ zeeman 1
                 cmd_args,
             )
 
-            # self.assertTrue(os.path.exists("{0}/custom_args.log".format(tmp_dir)))
+            # self.assertTrue(os.path.exists(os.path.join(out_tmp_dir, 'custom_args.log')))
             self.assertTrue(os.path.exists("{0}/test_1.dat".format(tmp_dir)))
 
     def test_main_custom_args(self):
@@ -43,9 +43,9 @@ zeeman 1
             with tempfile.TemporaryDirectory() as out_tmp_dir:
                 cmd_args = [
                     "-o",
-                    "{0}".format(out_tmp_dir),
+                    f"{out_tmp_dir}",
                     "-l",
-                    "{0}/new_test.log".format(out_tmp_dir),
+                    f"{out_tmp_dir}/new_test.log",
                 ]
                 inp_file_path = os.path.join(tmp_dir, "custom_args.in")
                 run_experiment(
@@ -61,8 +61,8 @@ zeeman 1
                     cmd_args,
                 )
 
-                # self.assertTrue(os.path.exists("{0}/new_test.log".format(out_tmp_dir)))
-                self.assertTrue(os.path.exists("{0}/test_2.dat".format(out_tmp_dir)))
+                # self.assertTrue(os.path.exists(os.path.join(out_tmp_dir, 'new_test.log')))
+                self.assertTrue(os.path.exists(os.path.join(out_tmp_dir, "test_2.dat")))
 
     def test_main_fitting_default_args(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -88,11 +88,11 @@ dissipation 1
                 cmd_args,
             )
 
-            # self.assertTrue(os.path.exists("{0}/fitting_default_args.log".format(tmp_dir)))
-            self.assertTrue(os.path.exists("{0}/test_fitting.dat".format(tmp_dir)))
+            # self.assertTrue(os.path.exists(os.path.join(tmp_dir, 'fitting_default_args.log')))
+            self.assertTrue(os.path.exists(os.path.join(tmp_dir, "test_fitting.dat")))
             self.assertTrue(
                 os.path.exists(
-                    "{0}/fitting_default_args_fit_report.txt".format(tmp_dir)
+                    os.path.join(tmp_dir, "fitting_default_args_fit_report.txt")
                 )
             )
 
@@ -129,11 +129,11 @@ dissipation 1
             with tempfile.TemporaryDirectory() as out_tmp_dir:
                 cmd_args = [
                     "-o",
-                    "{0}".format(out_tmp_dir),
+                    f"{out_tmp_dir}",
                     "-l",
-                    "{0}/new_test.log".format(out_tmp_dir),
+                    f"{out_tmp_dir}/new_test.log",
                     "-f",
-                    "{0}/new_fit_report.txt".format(out_tmp_dir),
+                    f"{out_tmp_dir}/new_fit_report.txt",
                 ]
                 inp_file_path = os.path.join(tmp_dir, "test.in")
                 run_experiment(
@@ -156,10 +156,10 @@ dissipation 1
                     cmd_args,
                 )
 
-                # self.assertTrue(os.path.exists("{0}/new_test.log".format(out_tmp_dir)))
+                # self.assertTrue(os.path.exists(os.path.join(out_tmp_dir, 'new_test.log')))
                 self.assertTrue(
-                    os.path.exists("{0}/test_fitting.dat".format(out_tmp_dir))
+                    os.path.exists(os.path.join(out_tmp_dir, "test_fitting.dat"))
                 )
                 self.assertTrue(
-                    os.path.exists("{0}/new_fit_report.txt".format(out_tmp_dir))
+                    os.path.exists(os.path.join(out_tmp_dir, "new_fit_report.txt"))
                 )


### PR DESCRIPTION
simple change to add command line arguments to specify where to save output files and log files etc

```
muspinsim --help

usage: __main__.py [-h] [-o OUT_DIR] [-l LOG_PATH] [-f FITREPORT_PATH]
                   input_file

Muspinsim - A program designed to carry out spin dynamics calculations for
muon science experiments

positional arguments:
  input_file            filepath to muspinsim specially formatted text file
                        specifying simulation input parameters.

options:
  -h, --help            show this help message and exit
  -o OUT_DIR, --out-dir OUT_DIR
                        folder to store the output .dat files
  -l LOG_PATH, --log-path LOG_PATH
                        filepath to store simulation logs
  -f FITREPORT_PATH, --fitreport-path FITREPORT_PATH
                        filepath to store fit report if fitting parameters
                        given
```
