### PR TITLE
Implement Celio's method

### DIFF
--- a/muspinsim/celio.py
+++ b/muspinsim/celio.py
@@ -7,7 +7,6 @@ trotter expansion
 from dataclasses import dataclass
 import itertools
 import logging
-import time
 from typing import List
 import numpy as np
 from scipy import sparse
@@ -15,35 +14,42 @@ from qutip import Qobj
 
 from muspinsim.spinop import SpinOperator, DensityOperator
 
+
 @dataclass
 class CelioHContrib:
     """
     Stores a Hamiltonian contribution term for use with Celio's method
 
     Arguments:
-            matrix {matrix} -- Sparse matrix representing a contribution to the hamiltonian
-            other_dimension {int} -- Defines the product of the matrix sizes of any remaining spins that
-                               are not included in this hamiltonian contribution
-            permutation_order {[int]} -- Defines the order of permutations that will be needed
-                                         when constructing the contributioin to the trotter hamiltonian
-                                         after the matrix exponential
-            permutation_dimensions {[int]} -- Defines the size of the matrices involved in the kronecker
-                                              products that make up this contribution to the Hamiltonian
+            matrix {matrix} -- Sparse matrix representing a contribution to the
+                               hamiltonian
+            other_dimension {int} -- Defines the product of the matrix sizes of any
+                                     remaining spins that are not included in this
+                                     hamiltonian contribution
+            permutation_order {[int]} -- Defines the order of permutations that will be
+                                         needed when constructing the contributioin to
+                                         the trotter hamiltonian after the matrix
+                                         exponential
+            permutation_dimensions {[int]} -- Defines the size of the matrices involved
+                                              in the kronecker products that make up
+                                              this contribution to the Hamiltonian
     """
+
     matrix: sparse.csr_matrix
     other_dimension: int
     permute_order: List[int]
     permute_dimensions: List[int]
 
-class CelioHamiltonian():
+
+class CelioHamiltonian:
     def __init__(self, terms, k, spinsys):
         """Create a CelioHamiltonian
 
         Create a CelioHamiltonian for applying Celio's method
 
         Arguments:
-            terms {[InteractionTerm]} -- Interaction terms that will form part of the Trotter
-                                         expansion
+            terms {[InteractionTerm]} -- Interaction terms that will form part of the
+                                         Trotter expansion
             k {int} -- Factor to be used in the Trotter expansion
             spinsys {SpinSystem} -- SpinSystem required for computing the time evolution
         """
@@ -55,16 +61,17 @@ class CelioHamiltonian():
         return CelioHamiltonian(self._terms + x._terms, self._k, self._spinsys)
 
     def _calc_H_contribs(self) -> List[CelioHContrib]:
-        """Calculates and returns the Hamiltonian contributions required for Celio's method
+        """Calculates and returns the Hamiltonian contributions required for Celio's
+           method
 
-        Returns the hamiltonian contributions defined by this system of spins and the given
-        interactions. In general these are split up per group of indices defined in interactions
-        to minimise the need of matrix exponentials.
+        Returns the hamiltonian contributions defined by this system of spins and the
+        given interactions. In general these are split up per group of indices defined
+        in interactions to minimise the need of matrix exponentials.
 
         Returns:
-            H_contribs {[CelioHContrib]} -- List of matrices representing contributions to the
-                                            total system hamiltonians refered to in Celio's
-                                            method as H_i
+            H_contribs {[CelioHContrib]} -- List of matrices representing contributions
+                                            to the total system hamiltonians refered to
+                                            in Celio's method as H_i
         """
 
         spin_indices = range(0, len(self._spinsys.spins))
@@ -84,8 +91,12 @@ class CelioHamiltonian():
 
             # Only include necessary terms
             if len(spin_ints) != 0:
-                # Sum matrices with the same indices so we avoid lots of matrix exponentials
-                for indices, group in itertools.groupby(spin_ints, lambda term: term.indices):
+                # Sum matrices with the same indices so we avoid lots of matrix
+                # exponentials
+                for indices, group in itertools.groupby(
+                    spin_ints, lambda term: term.indices
+                ):
+
                     grouped_spin_ints = list(group)
 
                     H_contrib = np.sum([term.matrix for term in grouped_spin_ints])
@@ -97,32 +108,45 @@ class CelioHamiltonian():
                             if j in other_spins_copy:
                                 other_spins_copy.remove(j)
 
-                    other_dimension = np.product([self._spinsys.dimension[j] for j in other_spins_copy])
+                    other_dimension = np.product(
+                        [self._spinsys.dimension[j] for j in other_spins_copy]
+                    )
 
-                    # Order in which kronecker products will be performed in Celio's method
+                    # Order in which kronecker products will be performed in Celio's
+                    # method
                     spin_order = list(indices) + other_spins_copy
 
-                    # Order we need to permute in order to obtain the same order as was given in the input
+                    # Order we need to permute in order to obtain the same order as was
+                    # given in the input
                     permute_order = np.zeros(len(spin_order), dtype=np.int32)
                     for i, value in enumerate(spin_order):
                         permute_order[value] = i
 
-                    permute_dimensions = [self._spinsys.dimension[i] for i in spin_order]
+                    permute_dimensions = [
+                        self._spinsys.dimension[i] for i in spin_order
+                    ]
 
                     H_contribs.append(
-                        CelioHContrib(H_contrib, other_dimension, permute_order, permute_dimensions)
+                        CelioHContrib(
+                            H_contrib,
+                            other_dimension,
+                            permute_order,
+                            permute_dimensions,
+                        )
                     )
 
         return H_contribs
 
     def _calc_trotter_evol_op(self, time_step):
-        """Calculates and returns the Trotter expansion of the time evolution operator from the Hamiltonian contributions
+        """Calculates and returns the Trotter expansion of the time evolution operator
+           from the Hamiltonian contributions
 
         Arguments:
             time_step {float} -- Timestep that will be used during the evolution
 
         Returns:
-            evol_op {[matrix]} -- Result of the Trotter expansion of the evolution operator
+            evol_op {[matrix]} -- Result of the Trotter expansion of the evolution
+                                operator
         """
 
         H_contribs = self._calc_H_contribs()
@@ -130,24 +154,29 @@ class CelioHamiltonian():
         evol_op_contribs = []
 
         for H_contrib in H_contribs:
-            # The matrix is currently stored in csr format, but expm wants it in csc so convert here
-            evol_op_contrib = sparse.linalg.expm(-2j * np.pi * H_contrib.matrix.tocsc() * time_step / self._k).tocsr()
-
+            # The matrix is currently stored in csr format, but expm wants it in csc so
+            # convert here
+            evol_op_contrib = sparse.linalg.expm(
+                -2j * np.pi * H_contrib.matrix.tocsc() * time_step / self._k
+            ).tocsr()
 
             if H_contrib.other_dimension > 1:
-                evol_op_contrib = sparse.kron(evol_op_contrib, sparse.identity(H_contrib.other_dimension, format="csr"))
+                evol_op_contrib = sparse.kron(
+                    evol_op_contrib,
+                    sparse.identity(H_contrib.other_dimension, format="csr"),
+                )
 
             # For particle interactions that are not neighbours we must use a swap gate
             qtip_obj = Qobj(
                 inpt=evol_op_contrib,
-                dims=[H_contrib.permute_dimensions, H_contrib.permute_dimensions]
+                dims=[H_contrib.permute_dimensions, H_contrib.permute_dimensions],
             )
             qtip_obj = qtip_obj.permute(H_contrib.permute_order)
             evol_op_contrib = qtip_obj.data
 
             evol_op_contribs.append(evol_op_contrib)
 
-        return np.product(evol_op_contribs)**self._k
+        return np.product(evol_op_contribs) ** self._k
 
     def evolve(self, rho0, times, operators=[]):
         """Time evolution of a state under this Hamiltonian
@@ -189,9 +218,9 @@ class CelioHamiltonian():
             operators = [operators]
         if not all([isinstance(o, SpinOperator) for o in operators]):
             raise ValueError(
-                "operators must be a SpinOperator or a list" " of SpinOperator objects"
+                "operators must be a SpinOperator or a list of SpinOperator objects"
             )
-        
+
         time_step = times[1] - times[0]
         rho0 = rho0.matrix
 
@@ -202,16 +231,19 @@ class CelioHamiltonian():
         mat_density = evol_op.getnnz() / np.prod(evol_op.shape)
 
         if mat_density >= 0.08:
-            logging.warning("Matrix density is %s >= 0.08 and so Celio's method is not suitable, "
-                            "consider switching. Now using dense matrices to accelerate at the "
-                            "cost of memory usage.", mat_density)
-            # Matrix products with trotter_hamiltonian_dt is very likely to be slower with sparse
-            # matrices than dense
+            logging.warning(
+                "Matrix density is %s >= 0.08 and so Celio's method is not suitable, "
+                "consider disabling it.",
+                mat_density,
+            )
+            # Matrix products with trotter_hamiltonian_dt is very likely to be slower
+            # with sparse matrices than dense
 
-            # We can still save some memory over Hamiltonian's evolve method at the cost of
-            # performance by using dense matrices for trotter_hamiltonian trotter_hamiltonian_dt
-            # but the improvement is minimal and as the problem gets bigger the reduction in
-            # memory usage decreases and increase in time increases so does not appear worth it
+            # We can still save some memory over Hamiltonian's evolve method at the
+            # cost of performance by using dense matrices for trotter_hamiltonian
+            # trotter_hamiltonian_dt but the improvement is minimal and as the problem
+            # gets bigger the reduction in memory usage decreases and increase in time
+            # increases so does not appear worth it
 
         # Avoid using append as assignment should be faster
         results = np.zeros((times.shape[0], len(operators)), dtype=np.complex128)
@@ -221,17 +253,18 @@ class CelioHamiltonian():
             for i in range(times.shape[0]):
                 # When passing multiple operators we want to return results for each
                 for j, operator in enumerate(operators):
-                    # Using csc matrix for total_evol_op so that this operation is more efficient
-                    operator = total_evol_op.conj().T * (operator.matrix * total_evol_op).tocsr()
+                    # Using csc matrix for total_evol_op so that this operation is
+                    # more efficient
+                    operator = (
+                        total_evol_op.conj().T
+                        * (operator.matrix * total_evol_op).tocsr()
+                    )
 
                     # This element wise multiplication then sum gives the equivalent
-                    # as the trace of the matrix product since the matrices are symmetric
-                    # and is also faster
+                    # as the trace of the matrix product since the matrices are
+                    # symmetric and is also faster
                     results[i][j] = np.sum(
-                        np.sum(
-                            rho0.multiply(operator), axis=1
-                        ),
-                        axis=0
+                        np.sum(rho0.multiply(operator), axis=1), axis=0
                     )
 
                 # Evolution step

--- a/muspinsim/celio.py
+++ b/muspinsim/celio.py
@@ -1,0 +1,240 @@
+"""celio.py
+
+A class for handling the computation of hamiltonian for Celio's method via a
+trotter expansion
+"""
+
+from dataclasses import dataclass
+import itertools
+import logging
+import time
+from typing import List
+import numpy as np
+from scipy import sparse
+from qutip import Qobj
+
+from muspinsim.spinop import SpinOperator, DensityOperator
+
+@dataclass
+class CelioHContrib:
+    """
+    Stores a Hamiltonian contribution term for use with Celio's method
+
+    Arguments:
+            matrix {matrix} -- Sparse matrix representing a contribution to the hamiltonian
+            other_dimension {int} -- Defines the product of the matrix sizes of any remaining spins that
+                               are not included in this hamiltonian contribution
+            permutation_order {[int]} -- Defines the order of permutations that will be needed
+                                         when constructing the contributioin to the trotter hamiltonian
+                                         after the matrix exponential
+            permutation_dimensions {[int]} -- Defines the size of the matrices involved in the kronecker
+                                              products that make up this contribution to the Hamiltonian
+    """
+    matrix: sparse.csr_matrix
+    other_dimension: int
+    permute_order: List[int]
+    permute_dimensions: List[int]
+
+class CelioHamiltonian():
+    def __init__(self, terms, k, spinsys):
+        """Create a CelioHamiltonian
+
+        Create a CelioHamiltonian for applying Celio's method
+
+        Arguments:
+            terms {[InteractionTerm]} -- Interaction terms that will form part of the Trotter
+                                         expansion
+            k {int} -- Factor to be used in the Trotter expansion
+            spinsys {SpinSystem} -- SpinSystem required for computing the time evolution
+        """
+        self._terms = terms
+        self._k = k
+        self._spinsys = spinsys
+
+    def __add__(self, x):
+        return CelioHamiltonian(self._terms + x._terms, self._k, self._spinsys)
+
+    def _calc_H_contribs(self) -> List[CelioHContrib]:
+        """Calculates and returns the Hamiltonian contributions required for Celio's method
+
+        Returns the hamiltonian contributions defined by this system of spins and the given
+        interactions. In general these are split up per group of indices defined in interactions
+        to minimise the need of matrix exponentials.
+
+        Returns:
+            H_contribs {[CelioHContrib]} -- List of matrices representing contributions to the
+                                            total system hamiltonians refered to in Celio's
+                                            method as H_i
+        """
+
+        spin_indices = range(0, len(self._spinsys.spins))
+
+        H_contribs = []
+
+        for i in spin_indices:
+            # Only want to include each interaction once, will make the choice here to
+            # only add it to the H_i for the first particle listed in the interactions
+
+            # Find the terms that have the current spin as its first or only index
+            spin_ints = [term for term in (self._terms) if i == term.indices[0]]
+
+            # List of spin indices not included here
+            other_spins = list(range(0, len(self._spinsys.spins)))
+            other_spins.remove(i)
+
+            # Only include necessary terms
+            if len(spin_ints) != 0:
+                # Sum matrices with the same indices so we avoid lots of matrix exponentials
+                for indices, group in itertools.groupby(spin_ints, lambda term: term.indices):
+                    grouped_spin_ints = list(group)
+
+                    H_contrib = np.sum([term.matrix for term in grouped_spin_ints])
+
+                    # Find indices of spins not involved in the current interactions
+                    other_spins_copy = other_spins.copy()
+                    for term in grouped_spin_ints:
+                        for j in term.indices:
+                            if j in other_spins_copy:
+                                other_spins_copy.remove(j)
+
+                    other_dimension = np.product([self._spinsys.dimension[j] for j in other_spins_copy])
+
+                    # Order in which kronecker products will be performed in Celio's method
+                    spin_order = list(indices) + other_spins_copy
+
+                    # Order we need to permute in order to obtain the same order as was given in the input
+                    permute_order = np.zeros(len(spin_order), dtype=np.int32)
+                    for i, value in enumerate(spin_order):
+                        permute_order[value] = i
+
+                    permute_dimensions = [self._spinsys.dimension[i] for i in spin_order]
+
+                    H_contribs.append(
+                        CelioHContrib(H_contrib, other_dimension, permute_order, permute_dimensions)
+                    )
+
+        return H_contribs
+
+    def _calc_trotter_evol_op(self, time_step):
+        """Calculates and returns the Trotter expansion of the time evolution operator from the Hamiltonian contributions
+
+        Arguments:
+            time_step {float} -- Timestep that will be used during the evolution
+
+        Returns:
+            evol_op {[matrix]} -- Result of the Trotter expansion of the evolution operator
+        """
+
+        H_contribs = self._calc_H_contribs()
+
+        evol_op_contribs = []
+
+        for H_contrib in H_contribs:
+            # The matrix is currently stored in csr format, but expm wants it in csc so convert here
+            evol_op_contrib = sparse.linalg.expm(-2j * np.pi * H_contrib.matrix.tocsc() * time_step / self._k).tocsr()
+
+
+            if H_contrib.other_dimension > 1:
+                evol_op_contrib = sparse.kron(evol_op_contrib, sparse.identity(H_contrib.other_dimension, format="csr"))
+
+            # For particle interactions that are not neighbours we must use a swap gate
+            qtip_obj = Qobj(
+                inpt=evol_op_contrib,
+                dims=[H_contrib.permute_dimensions, H_contrib.permute_dimensions]
+            )
+            qtip_obj = qtip_obj.permute(H_contrib.permute_order)
+            evol_op_contrib = qtip_obj.data
+
+            evol_op_contribs.append(evol_op_contrib)
+
+        return np.product(evol_op_contribs)**self._k
+
+    def evolve(self, rho0, times, operators=[]):
+        """Time evolution of a state under this Hamiltonian
+
+        Perform an evolution of a state described by a DensityOperator under
+        this Hamiltonian and return either a sequence of DensityOperators or
+        a sequence of expectation values for given SpinOperators.
+
+        Arguments:
+            k {int} -- Factor used in the Trotter expansion
+            rho0 {DensityOperator} -- Initial state
+            times {ndarray} -- Times to compute the evolution for, in microseconds
+
+        Keyword Arguments:
+            operators {[SpinOperator]} -- List of SpinOperators to compute the
+                                          expectation values of at each step.
+                                          If omitted, the states' density
+                                          matrices will be returned instead
+                                           (default: {[]})
+
+        Returns:
+            [DensityOperator | ndarray] -- DensityOperators or expectation values
+
+        Raises:
+            TypeError -- Invalid operators
+            ValueError -- Invalid values of times or operators
+            RuntimeError -- Hamiltonian is not hermitian
+        """
+
+        if not isinstance(rho0, DensityOperator):
+            raise TypeError("rho0 must be a valid DensityOperator")
+
+        times = np.array(times)
+
+        if len(times.shape) != 1:
+            raise ValueError("times must be an array of values in microseconds")
+
+        if isinstance(operators, SpinOperator):
+            operators = [operators]
+        if not all([isinstance(o, SpinOperator) for o in operators]):
+            raise ValueError(
+                "operators must be a SpinOperator or a list" " of SpinOperator objects"
+            )
+        
+        time_step = times[1] - times[0]
+        rho0 = rho0.matrix
+
+        # Time evolution step that will modify the trotter_hamiltonian below
+        evol_op = self._calc_trotter_evol_op(time_step)
+        total_evol_op = sparse.identity(evol_op.shape[0], format="csc")
+
+        mat_density = evol_op.getnnz() / np.prod(evol_op.shape)
+
+        if mat_density >= 0.08:
+            logging.warning("Matrix density is %s >= 0.08 and so Celio's method is not suitable, "
+                            "consider switching. Now using dense matrices to accelerate at the "
+                            "cost of memory usage.", mat_density)
+            # Matrix products with trotter_hamiltonian_dt is very likely to be slower with sparse
+            # matrices than dense
+
+            # We can still save some memory over Hamiltonian's evolve method at the cost of
+            # performance by using dense matrices for trotter_hamiltonian trotter_hamiltonian_dt
+            # but the improvement is minimal and as the problem gets bigger the reduction in
+            # memory usage decreases and increase in time increases so does not appear worth it
+
+        # Avoid using append as assignment should be faster
+        results = np.zeros((times.shape[0], len(operators)), dtype=np.complex128)
+
+        if len(operators) > 0:
+            # Compute expectation values one at a time
+            for i in range(times.shape[0]):
+                # When passing multiple operators we want to return results for each
+                for j, operator in enumerate(operators):
+                    # Using csc matrix for total_evol_op so that this operation is more efficient
+                    operator = total_evol_op.conj().T * (operator.matrix * total_evol_op).tocsr()
+
+                    # This element wise multiplication then sum gives the equivalent
+                    # as the trace of the matrix product since the matrices are symmetric
+                    # and is also faster
+                    results[i][j] = np.sum(
+                        np.sum(
+                            rho0.multiply(operator), axis=1
+                        ),
+                        axis=0
+                    )
+
+                # Evolution step
+                total_evol_op = total_evol_op * evol_op
+
+        return results

--- a/muspinsim/celio.py
+++ b/muspinsim/celio.py
@@ -271,3 +271,13 @@ class CelioHamiltonian:
                 total_evol_op = total_evol_op * evol_op
 
         return results
+
+    def integrate_decaying(self, rho0, tau, operators=[]):
+        """Called to integrate one or more expectation values in time with decay
+
+        Raises:
+            NotImplementedError
+        """
+        raise NotImplementedError(
+            "integrate_decaying is not implemented for Celio's method"
+        )

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -71,7 +71,7 @@ class ExperimentRunner(object):
 
         self._config = config
         self._system = config.system
-        
+
         # Store single spin operators
         self._single_spinops = np.array(
             [
@@ -219,8 +219,17 @@ class ExperimentRunner(object):
             else:
                 extra_terms = []
                 for i in range(len(self._system.spins)):
-                    extra_terms.append(SingleTerm(self._system, i, self._B * self._system.gammas[i], label="Zeeman"))
-                self._Hz = CelioHamiltonian(extra_terms, self.config.celio, self._system)
+                    extra_terms.append(
+                        SingleTerm(
+                            self._system,
+                            i,
+                            self._B * self._system.gammas[i],
+                            label="Zeeman",
+                        )
+                    )
+                self._Hz = CelioHamiltonian(
+                    extra_terms, self.config.celio, self._system
+                )
 
         return self._Hz
 

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -387,18 +387,18 @@ class ExperimentRunner(object):
                 print(all_dims)
                 
                 # For particle interactions that are not neighbours to the muon we must use a swap gate
-                if i != 0:
-                    all_dims[1], all_dims[i + 1] = all_dims[i + 1], all_dims[1]
-                    print(all_dims)
+                # if i != 0:
+                #     all_dims[1], all_dims[i + 1] = all_dims[i + 1], all_dims[1]
+                #     print(all_dims)
 
-                    def swap(total_spins, s1, s2):
-                        new_order = list(range(0, total_spins))
-                        new_order[s1], new_order[s2] = new_order[s2], new_order[s1]
-                        return new_order
+                #     def swap(total_spins, s1, s2):
+                #         new_order = list(range(0, total_spins))
+                #         new_order[s1], new_order[s2] = new_order[s2], new_order[s1]
+                #         return new_order
 
-                    qtip_obj = Qobj(inpt=evol_op, dims=[all_dims, all_dims])
-                    qtip_obj = qtip_obj.permute(swap(len(all_dims), 1, i + 1))
-                    evol_op = qtip_obj.data
+                #     qtip_obj = Qobj(inpt=evol_op, dims=[all_dims, all_dims])
+                #     qtip_obj = qtip_obj.permute(swap(len(all_dims), 1, i + 1))
+                #     evol_op = qtip_obj.data
 
                 dUs.append(evol_op)
 

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -380,32 +380,12 @@ class ExperimentRunner(object):
                 # H_i is currently stored in csr format, but expm wants it in csc so convert here
                 evol_op = sparse.linalg.expm(-2j * np.pi * H_i.tocsc() * time_step / k).tocsr()
 
-                all_spins = list((2*self.system.Is + 1).astype(int))
-
-                other_spins = np.array([self.system.Is[j] for j in range(0, len(self.system.Is)) if j != 0 and j != i + 1])
-                other_spins = (2*(2*other_spins + 1)).astype(int)
+                all_dims = list(self.system.dimension)
 
                 if dimensions[i] > 0:
                     evol_op = sparse.kron(evol_op, sparse.identity(dimensions[i], format="csr"))
-                
-                # Temporary attempt at swap gate
-                # if i == 1:
-                #     evol_op = sparse.kron(sparse.identity(2, format="csr"), sparse.csr_matrix([[1,0,0,0],[0,0,1,0],[0,1,0,0],[0,0,0,1]])) * evol_op
-                #     print(sparse.kron(sparse.identity(2, format="csr"), sparse.csr_matrix([[1,0,0,0],[0,0,1,0],[0,1,0,0],[0,0,0,1]])).toarray())
 
-                # Attempt to use QuTiP
-                # if i == 1:
-                #     def swap(total_spins, s1, s2):
-                #         new_order = list(range(0, l))
-                #         new_order[s1], new_order[s2] = new_order[s2], new_order[s1]
-                #         return new_order
-
-                #     # test2 = tensor([qeye(2), qeye(2), qeye(2)])
-                #     # print(test2.dims)
-
-                #     test = Qobj(inpt=evol_op, dims=[[2, 2, 2], [2, 2, 2]])
-                #     test = test.permute(swap(3, 1, 2))
-                #     evol_op = test.data
+                print("H_i shape and dimensions", H_i.shape, dimensions)
                 
                 # For particle interactions that are not neighbours to the muon we must use a swap gate
                 if i != 0:
@@ -414,8 +394,8 @@ class ExperimentRunner(object):
                         new_order[s1], new_order[s2] = new_order[s2], new_order[s1]
                         return new_order
 
-                    qtip_obj = Qobj(inpt=evol_op, dims=[all_spins, all_spins])
-                    qtip_obj = qtip_obj.permute(swap(len(all_spins), 1, i + 1))
+                    qtip_obj = Qobj(inpt=evol_op, dims=[all_dims, all_dims])
+                    qtip_obj = qtip_obj.permute(swap(len(all_dims), 1, i + 1))
                     evol_op = qtip_obj.data
                     
 

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -388,16 +388,17 @@ class ExperimentRunner(object):
                 
                 # For particle interactions that are not neighbours to the muon we must use a swap gate
                 if i != 0:
+                    all_dims[1], all_dims[i + 1] = all_dims[i + 1], all_dims[1]
+                    print(all_dims)
+
                     def swap(total_spins, s1, s2):
                         new_order = list(range(0, total_spins))
                         new_order[s1], new_order[s2] = new_order[s2], new_order[s1]
-                        print(new_order)
                         return new_order
 
                     qtip_obj = Qobj(inpt=evol_op, dims=[all_dims, all_dims])
                     qtip_obj = qtip_obj.permute(swap(len(all_dims), 1, i + 1))
                     evol_op = qtip_obj.data
-                    
 
                 dUs.append(evol_op)
 
@@ -440,7 +441,6 @@ class ExperimentRunner(object):
                         op = op.basis_change(trotter_hamiltonian).matrix.T
 
                         results[i][j] = (rho0 * op).trace()
-                        
                         
                     # Evolution step
                     trotter_hamiltonian = trotter_hamiltonian * trotter_hamiltonian_dt

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -427,14 +427,9 @@ class ExperimentRunner(object):
                     # When passing multiple operators we want to return results for each
                     for j, op in enumerate(operators):
                         op = op.basis_change(trotter_hamiltonian).matrix.T
+
+                        results[i][j] = (rho0 * op).trace()
                         
-                        # Sparse matrices dont allow axis as a tuple, so have to use sum twice
-                        results[i][j] = np.sum(
-                            np.sum(
-                                rho0.multiply(op), axis=1
-                            ),
-                            axis=0
-                        )
                         
                     # Evolution step
                     trotter_hamiltonian = trotter_hamiltonian * trotter_hamiltonian_dt

--- a/muspinsim/hamiltonian.py
+++ b/muspinsim/hamiltonian.py
@@ -93,6 +93,9 @@ class Hamiltonian(Operator, Hermitian):
             # Actually compute expectation values one at a time
             for i in range(times.shape[0]):
                 rho = calc_single_rho(i)
+                
+                # This element wise multiplication then sum gives the equivalent
+                # as the trace of the matrix product since the matrices are symmetric
                 single_res = np.sum(
                     rho[0, None, :, :] * operatorsT[None, :, :, :], axis=(2, 3)
                 )

--- a/muspinsim/hamiltonian.py
+++ b/muspinsim/hamiltonian.py
@@ -96,6 +96,7 @@ class Hamiltonian(Operator, Hermitian):
                 
                 # This element wise multiplication then sum gives the equivalent
                 # as the trace of the matrix product since the matrices are symmetric
+                # and is also faster
                 single_res = np.sum(
                     rho[0, None, :, :] * operatorsT[None, :, :, :], axis=(2, 3)
                 )

--- a/muspinsim/hamiltonian.py
+++ b/muspinsim/hamiltonian.py
@@ -93,7 +93,7 @@ class Hamiltonian(Operator, Hermitian):
             # Actually compute expectation values one at a time
             for i in range(times.shape[0]):
                 rho = calc_single_rho(i)
-                
+
                 # This element wise multiplication then sum gives the equivalent
                 # as the trace of the matrix product since the matrices are symmetric
                 # and is also faster

--- a/muspinsim/hamiltonian.py
+++ b/muspinsim/hamiltonian.py
@@ -95,8 +95,8 @@ class Hamiltonian(Operator, Hermitian):
                 rho = calc_single_rho(i)
 
                 # This element wise multiplication then sum gives the equivalent
-                # as the trace of the matrix product since the matrices are symmetric
-                # and is also faster
+                # as the trace of the matrix product (without the transpose) and
+                # and is faster
                 single_res = np.sum(
                     rho[0, None, :, :] * operatorsT[None, :, :, :], axis=(2, 3)
                 )

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -335,7 +335,6 @@ class KWName(MuSpinKeyword):
     accept_range = False
     default = "muspinsim"
 
-
 class KWSpins(MuSpinKeyword):
 
     name = "spins"
@@ -344,6 +343,12 @@ class KWSpins(MuSpinKeyword):
     accept_range = False
     default = "mu e"
 
+class KWCelio(MuSpinKeyword):
+
+    name = "celio"
+    block_size = 1
+    accept_range = False
+    default = "0"
 
 class KWPolarization(MuSpinExpandKeyword):
 

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -335,6 +335,7 @@ class KWName(MuSpinKeyword):
     accept_range = False
     default = "muspinsim"
 
+
 class KWSpins(MuSpinKeyword):
 
     name = "spins"
@@ -343,12 +344,14 @@ class KWSpins(MuSpinKeyword):
     accept_range = False
     default = "mu e"
 
+
 class KWCelio(MuSpinKeyword):
 
     name = "celio"
     block_size = 1
     accept_range = False
     default = "0"
+
 
 class KWPolarization(MuSpinExpandKeyword):
 

--- a/muspinsim/lindbladian.py
+++ b/muspinsim/lindbladian.py
@@ -5,6 +5,7 @@ SuperOperator class for Lindbladian, used in open quantum dynamics
 
 import numpy as np
 from numbers import Number
+from muspinsim.celio import CelioHamiltonian
 
 from muspinsim.hamiltonian import Hamiltonian
 from muspinsim.spinop import SuperOperator, SpinOperator, DensityOperator
@@ -14,6 +15,10 @@ class Lindbladian(SuperOperator):
     @classmethod
     def from_hamiltonian(self, H, dissipators=[]):
 
+        if isinstance(H, CelioHamiltonian):
+            raise NotImplementedError(
+                "Linbladian is not implemented for Celio's method"
+            )
         if not isinstance(H, Hamiltonian):
             raise ValueError("Must use Hamiltonian to create Lindbladian")
 

--- a/muspinsim/simconfig.py
+++ b/muspinsim/simconfig.py
@@ -488,9 +488,13 @@ Parameters used:
         try:
             trotter_k = int(v)
             if trotter_k < 0:
-                raise MuSpinConfigError("Value of k for Celio's method must a postive integer or 0")
+                raise MuSpinConfigError(
+                    "Value of k for Celio's method must a postive " "integer or 0"
+                )
         except ValueError:
-            raise MuSpinConfigError("Value of k for Celio's method must be an integer") from ValueError
+            raise MuSpinConfigError(
+                "Value of k for Celio's method must be an " "integer"
+            ) from ValueError
         return trotter_k
 
     def _validate_t(self, v):

--- a/muspinsim/simconfig.py
+++ b/muspinsim/simconfig.py
@@ -103,6 +103,7 @@ class MuSpinConfig(object):
         # Basic parameters
         self._name = self.validate("name", params["name"].value)[0]
         self._spins = self.validate("spins", params["spins"].value[0])
+        self._celio = self.validate("celio", params["celio"].value[0])[0]
         self._y_axis = self.validate("y", params["y_axis"].value[0])[0]
 
         # Identify ranges
@@ -206,7 +207,7 @@ class MuSpinConfig(object):
             _log_dictranges(self._file_ranges)
 
         # Now make the spin system
-        self._system = MuonSpinSystem(self._spins)
+        self._system = MuonSpinSystem(self._spins, self._celio)
         self._dissip_terms = {}
 
         for iid, idata in params["couplings"].items():
@@ -396,6 +397,10 @@ Parameters used:
         return list(self._spins)
 
     @property
+    def celio(self):
+        return self._celio
+
+    @property
     def system(self):
         return self._system.clone()
 
@@ -477,6 +482,16 @@ Parameters used:
             A, el = m.groups()
             A = int(A)
             return (el, A)
+
+    def _validate_celio(self, v):
+        trotter_k = 0
+        try:
+            trotter_k = int(v)
+            if trotter_k < 0:
+                raise MuSpinConfigError("Value of k for Celio's method must a postive integer or 0")
+        except ValueError:
+            raise MuSpinConfigError("Value of k for Celio's method must be an integer") from ValueError
+        return trotter_k
 
     def _validate_t(self, v):
         if len(v) != 1:

--- a/muspinsim/spinsys.py
+++ b/muspinsim/spinsys.py
@@ -43,7 +43,7 @@ class InteractionTerm(Clonable):
         for ii in index_tuples:
             op = (
                 self._spinsys.operator(
-                    {ind: "xyz"[ii[i]] for i, ind in enumerate(self._indices)}, include_only_given=self._spinsys.celios
+                    {ind: "xyz"[ii[i]] for i, ind in enumerate(self._indices)}, include_only_given=self._spinsys.celio
                 )
                 * self._tensor[tuple(ii)]
             )
@@ -150,7 +150,7 @@ class DissipationTerm(Clonable):
 
 
 class SpinSystem(Clonable):
-    def __init__(self, spins=[]):
+    def __init__(self, spins=[], celio=0):
         """Create a SpinSystem object
 
         Create an object representing a system of particles with spins (muons,
@@ -161,6 +161,9 @@ class SpinSystem(Clonable):
                             Each element can be 'e' (electron), 'mu' (muon) a
                             chemical symbol, or a (str, int) tuple with a
                             chemical symbol and an isotope (default: {[]})
+            celio {int} -- Factor for the Trotter approximation if Celio's
+                           method is to be used. When this is 0, Celio's method
+                           is not used.
         """
 
         gammas = []
@@ -193,7 +196,7 @@ class SpinSystem(Clonable):
         self._terms = []
         self._dissip_terms = []
 
-        self.celios = True
+        self._celio = celio
 
         snames = [
             "{1}{0}".format(*s) if (type(s) == tuple) else str(s) for s in self._spins
@@ -204,6 +207,10 @@ class SpinSystem(Clonable):
     @property
     def spins(self):
         return list(self._spins)
+
+    @property
+    def celio(self):
+        return self._celio
 
     @property
     def gammas(self):
@@ -604,9 +611,9 @@ class SpinSystem(Clonable):
 
 
 class MuonSpinSystem(SpinSystem):
-    def __init__(self, spins=["mu", "e"]):
+    def __init__(self, spins=["mu", "e"], celio=0):
 
-        super(MuonSpinSystem, self).__init__(spins)
+        super(MuonSpinSystem, self).__init__(spins, celio)
 
         # Identify the muon index
         if self._spins.count("mu") != 1:

--- a/muspinsim/spinsys.py
+++ b/muspinsim/spinsys.py
@@ -44,7 +44,8 @@ class InteractionTerm(Clonable):
         for ii in index_tuples:
             op = (
                 self._spinsys.operator(
-                    {ind: "xyz"[ii[i]] for i, ind in enumerate(self._indices)}, include_only_given=self._spinsys.celio
+                    {ind: "xyz"[ii[i]] for i, ind in enumerate(self._indices)},
+                    include_only_given=self._spinsys.celio,
                 )
                 * self._tensor[tuple(ii)]
             )
@@ -553,8 +554,13 @@ class SpinSystem(Clonable):
         """
 
         if include_only_given:
-            # For Celio's method wont need all of the 0's, just the ones relevant to the interaction itself
-            ops = [self._operators[i][terms.get(i, "0")] for i in range(len(self)) if terms.get(i, "0") != "0"]
+            # For Celio's method wont need all of the 0's, just the ones relevant to
+            # the interaction itself
+            ops = [
+                self._operators[i][terms.get(i, "0")]
+                for i in range(len(self))
+                if terms.get(i, "0") != "0"
+            ]
         else:
             ops = [self._operators[i][terms.get(i, "0")] for i in range(len(self))]
 
@@ -611,6 +617,7 @@ class SpinSystem(Clonable):
 
     def __len__(self):
         return len(self._gammas)
+
 
 class MuonSpinSystem(SpinSystem):
     def __init__(self, spins=["mu", "e"], celio=0):

--- a/muspinsim/spinsys.py
+++ b/muspinsim/spinsys.py
@@ -739,9 +739,6 @@ class MuonSpinSystem(SpinSystem):
             H_contribs {[CelioHContrib]} -- List of matrices representing contributions to the total system hamiltonians
                                             refered to in Celio's method as H_i
         """
-
-        if self.muon_index != 0:
-            raise ValueError("The muon must be the first spin")
         
         spin_indices = range(0, len(self.spins))
 

--- a/muspinsim/spinsys.py
+++ b/muspinsim/spinsys.py
@@ -729,7 +729,7 @@ class MuonSpinSystem(SpinSystem):
 
         return op
 
-    def calc_celios_H_contribs(self) -> List[CelioHContrib]:
+    def calc_celios_H_contribs(self, extra_terms) -> List[CelioHContrib]:
         """Calculates and returns the hamiltonian contributions required for Celio's method
 
         Returns the hamiltonian contributions defined by this system of spins and the given interactions. In general
@@ -751,7 +751,7 @@ class MuonSpinSystem(SpinSystem):
             # only add it to the H_i for the first particle listed in the interactions
 
             # Find the terms that have the current spin as its first or only index
-            spin_ints = [term for term in self._terms if i == term.indices[0]]
+            spin_ints = [term for term in (self._terms + extra_terms) if i == term.indices[0]]
 
             # List of spin indices not included here
             other_spins = list(range(0, len(self.spins)))

--- a/muspinsim/spinsys.py
+++ b/muspinsim/spinsys.py
@@ -748,9 +748,6 @@ class MuonSpinSystem(SpinSystem):
         print(muon_H_contribs)
 
         # For now we will assume all interactions include the muon and a maximum of one other particle
-        # Will also assume swap gates aren't needed yet - i.e. can only have interactions of the muon and
-        # the particle that is defined directly after it
-
         for i in non_muon_indices:
             # Find the terms that involve the current particle
             particle_ints = [term for term in other_ints if i in term.indices]
@@ -789,9 +786,9 @@ class MuonSpinSystem(SpinSystem):
 
             hamiltonians.append(particle_H)
 
-        print("END")
-
         print("DimArray", dimensions)
+
+        print("END")
 
         # sys.exit()
 

--- a/muspinsim/spinsys.py
+++ b/muspinsim/spinsys.py
@@ -6,6 +6,7 @@ A class to hold a given spin system, defined by specific nuclei
 from dataclasses import dataclass
 import itertools
 import logging
+import time
 from typing import List
 
 import numpy as np
@@ -746,7 +747,8 @@ class MuonSpinSystem(SpinSystem):
 
         H_contribs = []
 
-        # TODO: Make this more general so can have single index interactions and double ones, not just one or the other
+        t_start = time.time()
+
         for i in spin_indices:
             # Only want to include each interaction once, will make the choice here to
             # only add it to the H_i for the first particle listed in the interactions
@@ -793,5 +795,7 @@ class MuonSpinSystem(SpinSystem):
                     print(f"Permute dimensions {permute_dimensions}")
 
                     H_contribs.append(CelioHContrib(H_contrib, other_dimension, permute_order, permute_dimensions))
+
+        print(f"Time computing H_contribs {time.time() - t_start}")
 
         return H_contribs

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
-    install_requires=["numpy", "scipy", "soprano", "lark"],
+    install_requires=["numpy", "scipy", "soprano", "lark", "qutip"],
     extras_require={
         "docs": ["mkdocs", "pymdown-extensions"],
         "dev": ["flake8", "black>=22.3.0", "pytest", "pre-commit"],


### PR DESCRIPTION
This PR implements Celio's method as described https://github.com/muon-spectroscopy-computational-project/Developer-notes/files/9674894/PhysRevLett.56.2720.pdf and here https://undi.readthedocs.io/en/latest/. In general this should be faster than before in cases where the matrix generated is sufficiently sparse which is typically the case for large spins with simple interactions. In these cases it also avoids excessive memory usage as we no longer need to compute any eigenvectors.

To use this, simply add a line in the input file like
```
celio
    10
```
The number indicates the order of the Trotter expansion used in the calculation. Passing a value of 0 will revert back to using the old method. Higher values are generally more accurate but in more complex calculations can make the matrix less sparse slowing the calculation down. I have comfortably used values of k = 10000 in testing but values that are too large also risk increasing potential errors in the calculation. The best value of k will be dependent on the exact system.

Additional notes:
- A warning message is added to the logs when matrix sparsity exceeds 0.08, this is a threshold I observed in testing as causing Celio's method to be slower than before due to the extra matrix products