### PR TITLE
Add documentation for the faster method

### DIFF
--- a/docs/docs/hamiltonian.md
+++ b/docs/docs/hamiltonian.md
@@ -49,7 +49,7 @@ Dipole-dipole interactions are the result of one spin interacting with the magne
 Given two spins $i$ and $j$, and a vector connecting them $\mathbf{r}_{ij}$, the dipolar tensor for them can be computed as:
 
 $$
-\mathbf{D}_{ij} = -\frac{\mu_0\hbar \gamma_i \gamma_j}{2|r_{ij}|^3}\left(\frac{3}{|r_{ij}|^2}\mathbf{r}_{ij}\otimes \mathbf{r}_{ij} - \mathbb{I} \right)
+\mathbf{D}_{ij} = -\frac{\mu_0\hbar \gamma_i \gamma_j}{2|r_{ij}|^3}\left(\frac{3}{|r_{ij}|^2}\mathbf{r}_{ij}\otimes \mathbf{r}_{ij} - \mathbb{1} \right)
 $$
 
 This will return a tensor in frequency units, and thus the dipolar Hamiltonian can be defined like the hyperfine one:

--- a/docs/docs/theory_1.md
+++ b/docs/docs/theory_1.md
@@ -387,7 +387,7 @@ $$
 Sometimes, even in a system with multiple spins, operators involving only one of them, like $S_x^\mu$, might be relevant. In that case we must understand them as having an implicit identity matrix for all the spins that don't appear explicitly. So we have:
 
 $$
-S_x^\mu = S_x^\mu\mathbb{I}^e =
+S_x^\mu = S_x^\mu\mathbb{1}^e =
 \begin{bmatrix}
 0 & \frac{1}{2} \\
 \frac{1}{2} & 0

--- a/docs/docs/theory_2.md
+++ b/docs/docs/theory_2.md
@@ -53,7 +53,7 @@ This way we can see that the equations are completely decoupled. Coefficients on
 When simulating systems where $\frac{B}{T} \rightarrow 0$, i.e. when we have zero external magnetic field or the temperature $T \rightarrow \infty$, MuSpinSim will automatically employ a faster method of time evolution. To explain this method we first note that the density matrix at $t=0$ for the muon polarised along a direction ${\hat n}$ can be written as
 
 $$
- \rho_\mu (t=0) = \frac{1}{2}(1 + \sigma_\mu^{\hat n}),
+ \rho_\mu (t=0) = \frac{1}{2}(\mathbb{1} + \sigma_\mu^{\hat n}),
 $$
 
 and hence the density matrix of the full system is, (defining $d =\prod_{i \neq 0} 2I_i + 1$ as the dimension of the Hilbert space without the muon)
@@ -140,7 +140,7 @@ $$
 Finally, by expressing the exponentials in terms of $\sin$ and $\cos$, we may simplify the expression to
 
 $$
-P^{\hat n}_\mu(t) = \frac{1}{2d}\sum_{\alpha = \beta}\Big|\langle\alpha|\sigma_{\mu}^{\hat{n}}|\beta\rangle\Big|^2 + \frac{1}{d}\sum_{\alpha > \beta} \Big| \langle \alpha | \sigma_\mu^{\hat n}(0) |\beta \rangle \Big|^2 \cos [(E_\beta-E_\alpha) t].
+P^{\hat n}_\mu(t) = \frac{1}{2d}\sum_{\alpha = \beta}\Big|\langle\alpha|\sigma_{\mu}^{\hat{n}}|\beta\rangle\Big|^2 + \frac{1}{d}\sum_{\alpha < \beta} \Big| \langle \alpha | \sigma_\mu^{\hat n}(0) |\beta \rangle \Big|^2 \cos [(E_\beta-E_\alpha) t].
 $$
 
 When installed with OpenMP, MuSpinSim will parallelise this method over the time values, so when computing for 100 times, it will run on up to 100 threads.
@@ -192,7 +192,7 @@ For a further speedup we can continue to follow Celio's method, approximating th
 Here instead of evolving the density matrix, we instead evolve $\sigma_{\mu}=2I_{\mu}$ which are the Pauli matrices in the direction of the muon.
 
 $$
-\sigma_{\mu}(t) = e^{\frac{iHt}{\hbar}}\sigma_{\mu}e^{-\frac{iHt}{\hbar}}
+\sigma_{\mu}(t) = e^{-\frac{i}{\hbar}Ht}\sigma_{\mu}e^{\frac{i}{\hbar}Ht}
 $$
 
 Then by choosing a representation where $\sigma_{\mu}$ is diagonal we can write the muon polarisation as

--- a/docs/docs/theory_2.md
+++ b/docs/docs/theory_2.md
@@ -50,20 +50,20 @@ This way we can see that the equations are completely decoupled. Coefficients on
 
 #### A faster method
 
-For cases when $\frac{B}{T} \rightarrow 0$, for instance when we are simulating a zero field experiment or one where we take $T\rightarrow = \infty$, we no longer need the density matrix and automatically employ a faster method. To do we can first note that we will be dealing with a spin-polarised muon with various other unpolarised spins. The density matrix at $t=0$ for the muon polarised along ${\hat n}$ can be written as
+When simulating systems where $\frac{B}{T} \rightarrow 0$, i.e. when we have zero external magnetic field or the temperature $T \rightarrow \infty$, MuSpinSim will automatically employ a faster method of time evolution. To explain this method we first note that the density matrix at $t=0$ for the muon polarised along a direction ${\hat n}$ can be written as
 
 $$
  \rho_\mu (t=0) = \frac{1}{2}(1 + \sigma_\mu^{\hat n}),
 $$
 
-and hence the density matrix of the full system is, (defining $d =\prod_{i \neq 0} 2I_i + 1$ as the dimension of the Hilbert space without the muon), 
+and hence the density matrix of the full system is, (defining $d =\prod_{i \neq 0} 2I_i + 1$ as the dimension of the Hilbert space without the muon)
 
 $$
  \rho(t=0) = \frac{1}{2}(\mathbb{1}+\sigma_\mu^{\hat n}) \otimes \frac{1}{d}\mathbb{1}_d.
 $$
 
 Here we want to calculate the time dependence of the muon polarisation along ${\hat n}$, which is given by (notational abuse 
-means $\sigma_\mu^{\hat n}(t) = e^{iHt}(\sigma_\mu^{\hat n} \otimes \mathbb{1}_d) e^{-iHt}$)
+means $\sigma_\mu^{\hat n}(t) = e^{-\frac{i}{\hbar}Ht}(\sigma_\mu^{\hat n} \otimes \mathbb{1}_d) e^{\frac{i}{\hbar}Ht}$)
 
 $$
  P^{\hat n}_\mu(t) = \mathrm{Tr}[\rho(t)\sigma_\mu^{\hat n}(0)] = \mathrm{Tr}[\rho(t=0)\sigma_\mu^{\hat n}(t)].
@@ -106,14 +106,14 @@ Explicitly writing out the time dependance, we get
 
 $$
 P^{\hat n}_\mu(t) = \frac{1}{2d}\sum_{\alpha, \beta, \gamma} \langle \alpha | \sigma_\mu^{\hat n}(0) |\beta \rangle e^{iE_\beta t} \langle \beta | \sigma_\mu^{\hat n}(0)
-|\gamma \rangle e^{-iE_\beta t} \langle \gamma | \alpha \rangle,
+|\gamma \rangle e^{-iE_\gamma t} \langle \gamma | \alpha \rangle,
 $$
 
 and as $\langle \gamma | \alpha \rangle = \delta_{\gamma, \alpha}$, this simplifies to
 
 $$
 P^{\hat n}_\mu(t) = \frac{1}{2d}\sum_{\alpha, \beta} \langle \alpha | \sigma_\mu^{\hat n}(0) |\beta \rangle e^{iE_\beta t} \langle \beta | \sigma_\mu^{\hat n}(0)
-|\alpha \rangle e^{-iE_\beta t},
+|\alpha \rangle e^{-iE_\alpha t},
 $$
 
 so that
@@ -122,10 +122,25 @@ $$
 P^{\hat n}_\mu(t) = \frac{1}{2d}\sum_{\alpha, \beta} \Big| \langle \alpha | \sigma_\mu^{\hat n}(0) |\beta \rangle \Big|^2 e^{i(E_\beta-E_\alpha) t}.
 $$
 
-Simplifying this further we find
+Then, we can separate these terms into
 
 $$
-P^{\hat n}_\mu(t) = \frac{1}{2d}\sum_{\alpha, \beta}\Big|\langle\alpha|\sigma_{\mu}^{\hat{n}}|\beta\rangle\Big|^2 + \frac{1}{d}\sum_{\alpha > \beta} \Big| \langle \alpha | \sigma_\mu^{\hat n}(0) |\beta \rangle \Big|^2 \cos [(E_\beta-E_\alpha) t].
+\begin{aligned}
+P^{\hat n}_\mu(t) & = \frac{1}{2d}\sum_{\alpha = \beta} \Big| \langle \alpha | \sigma_\mu^{\hat n}(0) |\beta \rangle \Big|^2 e^{i(E_\beta-E_\alpha) t} \\
+& + \frac{1}{2d}\sum_{\alpha < \beta} \Big| \langle \alpha | \sigma_\mu^{\hat n}(0) |\beta \rangle \Big|^2 e^{i(E_\beta-E_\alpha) t} + \frac{1}{2d}\sum_{\alpha > \beta} \Big| \langle \alpha | \sigma_\mu^{\hat n}(0) |\beta \rangle \Big|^2 e^{i(E_\beta-E_\alpha) t}.
+\end{aligned}
+$$
+
+Now by swapping $\alpha$ and $\beta$ in the last term, we see that it is the same as the second term apart from a sign in the exponential, so they may combined to give
+
+$$
+P^{\hat n}_\mu(t) = \frac{1}{2d}\sum_{\alpha = \beta} \Big| \langle \alpha | \sigma_\mu^{\hat n}(0) |\beta \rangle \Big|^2 e^{i(E_\beta-E_\alpha) t} + \frac{1}{2d}\sum_{\alpha < \beta} \Big| \langle \alpha | \sigma_\mu^{\hat n}(0) |\beta \rangle \Big|^2 [e^{i(E_\beta-E_\alpha) t} + e^{-i(E_\beta-E_\alpha) t}].
+$$
+
+Finally, by expressing the exponentials in terms of $\sin$ and $\cos$, we may simplify the expression to
+
+$$
+P^{\hat n}_\mu(t) = \frac{1}{2d}\sum_{\alpha = \beta}\Big|\langle\alpha|\sigma_{\mu}^{\hat{n}}|\beta\rangle\Big|^2 + \frac{1}{d}\sum_{\alpha > \beta} \Big| \langle \alpha | \sigma_\mu^{\hat n}(0) |\beta \rangle \Big|^2 \cos [(E_\beta-E_\alpha) t].
 $$
 
 When installed with OpenMP, MuSpinSim will parallelise this method over the time values, so when computing for 100 times, it will run on up to 100 threads.


### PR DESCRIPTION
Adds a section to the documentation describing the speedup for T->inf/B=0 cases as implemented in #22. I have pretty much copied Johnny's explanation from https://github.com/muon-spectroscopy-computational-project/Developer-notes/blob/main/muspinsim/speedup_suggestions.md.

Also noticed the docs mentioned implementing faster approximate methods of time evolution in the future so modified it to mention celio's.