### PR TITLE
Fix repeated system creation and add ase to dependencies

### DIFF
--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -58,7 +58,7 @@ Each of these orientations will contribute an oscillation like the one above wit
 ## Example 4 - Avoided Level Crossing
 **Input file:** `examples/alc/alc.in`
 
-A simple example of an Avoided Level Crossing experiment involving three spins: a muon, an electron, and a hydrogen atom. Both muon and hydrogen are coupled via hyperfine coupling to the electron. The tensors are orientation dependent, and an average is carried out over different orientations (because this is an experiment with longitudinal polarisation, the `zcw` averaging should be sufficient, and is much cheaper than `eulrange`). The result can be seen as one major $\Delta_1$ peak around 2.1 T and a much smaller $\Delta_0$ one at 2.3 T.
+A simple example of an Avoided Level Crossing experiment involving three spins: a muon, an electron, and a hydrogen atom. Both the muon and the hydrogen are coupled to the electron by the hyperfine interaction. The tensors are orientation dependent, and an average is carried out over different orientations (because this is an experiment with longitudinal polarisation, the `zcw` averaging should be sufficient, and is much cheaper than `eulrange`). The result can be seen as one major $\Delta_1$ peak around 2.1 T and a much smaller $\Delta_0$ one at 2.3 T.
 
 ![](./figExALC.png)
 

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -54,7 +54,12 @@ class ExperimentRunner(object):
         mpi.broadcast_object(config, attrs)
 
         # broadcast _system attribute without _terms attribute
-        system = config.__dict__.get("_system", MuonSpinSystem())
+        system = config.__dict__.get("_system", None)
+
+        # Create default system only if none found
+        if system is None:
+            system = MuonSpinSystem()
+
         attrs = list(system.__dict__.keys())
         if "_terms" in attrs:
             attrs.remove("_terms")

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,7 @@ def setup():
         # Includes are needed for Cython compilation
         setup_requires=["numpy"],
         install_requires=[
+            "ase",
             "numpy",
             "scipy",
             "soprano",


### PR DESCRIPTION
Stops repeated creation of SpinSystem instances that are never used, especially when fitting. Also adds ase to the dependencies in setup.py as it was missing before.

Also makes a minor change to the wording of the ALC experiment docs to match https://github.com/muon-spectroscopy-computational-project/training-material/pull/4#discussion_r1044524599

Closes #30, Closes #18.