### PR TITLE
Allow intrinsic magnetic fields

### DIFF
--- a/docs/docs/input.md
+++ b/docs/docs/input.md
@@ -146,7 +146,27 @@ field
     4*MHz
 ```
 
-A single field, or range of magnetic fields, in Tesla, to simulate. These can be scalars or vectors; if scalars, the field will be assumed to be aligned with the Z axis. The function `range` expands into a number of values - by default, 50 of them, if only the start and end are specified. The default value is zero.
+A single or range of external magnetic fields, in Tesla, to simulate. These can be scalars or vectors; if scalars, the field will be assumed to be aligned with the Z axis. The function `range` expands into a number of values - by default, 50 of them, if only the start and end are specified. The default value is zero. This field type will be affected by any orientation changes such as when doing an angular average.
+
+### intrinsic_field 
+
+| Keyword:              |                    `intrinsic_field`
+|-----------------------|---------------------------:|
+| Allows multiple rows: |                        Yes |
+| Allows expressions:   |                        Yes |
+| Allows constants:     | default, `MHz`, `muon_gyr` |
+| Allows functions:     |           default, `range` |
+
+*Example:*
+```plaintext
+intrinsic_field
+    0
+    1*MHz
+    2*MHz
+    4*MHz
+```
+
+A single or range of intrinsic magnetic fields, in Tesla, to simulate. These can be scalars or vectors; if scalars, the field will be assumed to be aligned with the Z axis. The function `range` expands into a number of values - by default, 50 of them, if only the start and end are specified. The default value is zero. This field type will be unaffected by any orientation changes such as when doing an angular average.
 
 ### time
 

--- a/docs/docs/input.md
+++ b/docs/docs/input.md
@@ -150,7 +150,7 @@ A single or range of external magnetic fields, in Tesla, to simulate. These can 
 
 ### intrinsic_field 
 
-| Keyword:              |                    `intrinsic_field`
+| Keyword:              |          `intrinsic_field` |
 |-----------------------|---------------------------:|
 | Allows multiple rows: |                        Yes |
 | Allows expressions:   |                        Yes |
@@ -189,11 +189,11 @@ A time or range of times, in microseconds, to simulate. Used by default as the `
 ### x_axis
 
 | Keyword:              |           `x_axis` |
-|-----------------------|-----------------:|
-| Allows multiple rows: |             No |
-| Allows expressions:   |              No|
-| Allows constants:     |          N/A |
-| Allows functions:     | N/A|
+|-----------------------|-------------------:|
+| Allows multiple rows: |                 No |
+| Allows expressions:   |                 No |
+| Allows constants:     |                N/A |
+| Allows functions:     |                N/A |
 
 *Example:*
 ```plaintext

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -358,6 +358,10 @@ class ExperimentRunner(object):
         self.p = q.rotate(p)
         self.T = T
 
+        # Magnetic field is sum of external field (rotated with angular
+        # averages) and the intrinsic field that should not be rotated
+        self.B += cfg_snap.intrinsic_B
+
         # Figure out if a speedup is suitable
         B = np.linalg.norm(self.B)
         check_result = (cnst.e * (cnst.hbar**2) * B) / (2 * cnst.m_p * cnst.k * T)

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -378,6 +378,16 @@ class KWField(MuSpinExpandKeyword):
     _constants = {**_math_constants, **_phys_constants}
 
 
+class KWIntrinsicField(MuSpinExpandKeyword):
+
+    name = "intrinsic_field"
+    block_size = 1
+    accept_range = True
+    accept_as_x = True
+    default = "0.0"
+    _constants = {**_math_constants, **_phys_constants}
+
+
 class KWTime(MuSpinExpandKeyword):
 
     name = "time"

--- a/muspinsim/simconfig.py
+++ b/muspinsim/simconfig.py
@@ -22,6 +22,7 @@ from muspinsim.utils import quat_from_polar
 _CDICT = {
     "polarization": "mupol",
     "field": "B",
+    "intrinsic_field": "intrinsic_B",
     "time": "t",
     "orientation": "orient",
     "temperature": "T",
@@ -362,7 +363,7 @@ Parameters used:
 
         x = self.x_axis_values
 
-        if "B" in self._x_range.keys():
+        if "B" in self._x_range.keys() or "intrinsic_B" in self._x_range.keys():
             x = np.linalg.norm(x, axis=-1)
 
         # Actually save the files
@@ -538,6 +539,15 @@ Parameters used:
 
         return v
 
+    def _validate_intrinsic_B(self, v):
+
+        if len(v) == 1:
+            v = np.array([0, 0, v[0]])  # The default direction is Z
+        elif len(v) != 3:
+            raise MuSpinConfigError("Invalid intrinsic magnetic field value")
+
+        return v
+
     def _validate_mupol(self, v):
         v = np.array(v, dtype=float)
         if len(v) != 3:
@@ -562,8 +572,8 @@ Parameters used:
 
         # After computing the rotation, we store the conjugate because it's a
         # lot cheaper, instead of rotating the whole system by q, to rotate
-        # only the magnetic field and the polarization (lab frame) by the
-        # inverse of q
+        # only the external magnetic field and the polarization (lab frame) by
+        # the inverse of q
 
         return (q.conjugate(), w)
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -17,6 +17,8 @@ spins
     mu 2H e
 field
     range(1, 11, 2)
+intrinsic_field
+    range(1, 21, 2)
 temperature
     range(0, 10, 2)
 time
@@ -48,13 +50,14 @@ dissipation 2
         cfg = MuSpinConfig(itest.evaluate())
 
         self.assertEqual(cfg.name, "muspinsim")
-        self.assertEqual(len(cfg), 8)
-        self.assertEqual(cfg.results.shape, (2, 2, 21))
+        self.assertEqual(len(cfg), 16)
+        self.assertEqual(cfg.results.shape, (2, 2, 2, 21))
 
         # Try getting one configuration snapshot
         cfg0 = cfg[0]
 
         self.assertTrue((cfg0.B == [0, 0, 1]).all())
+        self.assertTrue((cfg0.intrinsic_B == [0, 0, 1]).all())
         self.assertEqual(cfg0.T, 0)
         self.assertTrue((cfg0.t == np.linspace(0, 10, 21)).all())
         self.assertTrue(np.isclose(np.linalg.norm(cfg0.mupol), 1.0))

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -76,6 +76,7 @@ dissipation 2
         self.assertEqual(cfg._dissip_terms[1], 0.1)
 
         self.assertIn("B", cfg._file_ranges)
+        self.assertIn("intrinsic_B", cfg._file_ranges)
         self.assertIn("T", cfg._file_ranges)
         self.assertIn("t", cfg._x_range)
         self.assertIn("orient", cfg._avg_ranges)

--- a/test/test_experiment.py
+++ b/test/test_experiment.py
@@ -204,6 +204,53 @@ intrinsic_field
 
         self.assertAlmostEqual(results[0], 0.5 / (1.0 + 4 * np.pi**2 * tau**2))
 
+    def test_run_intrinsic_field(self):
+        # Check results from rotating are different when using field or intrinsic_field
+        stest = StringIO(
+            """
+spins
+    e mu
+time
+    range(0, 10)
+zeeman 2
+    0 0 1.0/muon_gyr
+orientation
+    zcw(1)
+field
+    10 0 0
+"""
+        )
+        itest = MuSpinInput(stest)
+        ertest = ExperimentRunner(itest)
+
+        results = ertest.run()
+
+        stest = StringIO(
+            """
+spins
+    e mu
+time
+    range(0, 10)
+zeeman 2
+    0 0 1.0/muon_gyr
+orientation
+    zcw(1)
+intrinsic_field
+    10 0 0
+"""
+        )
+        itest = MuSpinInput(stest)
+        ertest = ExperimentRunner(itest)
+
+        results_intrinsic = ertest.run()
+
+        np.testing.assert_raises(
+            AssertionError,
+            np.testing.assert_array_almost_equal,
+            results,
+            results_intrinsic,
+        )
+
     def test_run_celio(self):
 
         # Empty system

--- a/test/test_experiment.py
+++ b/test/test_experiment.py
@@ -179,6 +179,31 @@ field
 
         self.assertAlmostEqual(results[0], 0.5 / (1.0 + 4 * np.pi**2 * tau**2))
 
+        # Same result as above should hold for an intrinsic field
+        stest = StringIO(
+            """
+spins
+    e mu
+time
+    range(0, 10)
+zeeman 2
+    0 0 1.0/muon_gyr
+y_axis
+    integral
+x_axis
+    intrinsic_field
+intrinsic_field
+    0
+    1
+"""
+        )
+        itest = MuSpinInput(stest)
+        ertest = ExperimentRunner(itest)
+
+        results = ertest.run()
+
+        self.assertAlmostEqual(results[0], 0.5 / (1.0 + 4 * np.pi**2 * tau**2))
+
     def test_run_celio(self):
 
         # Empty system

--- a/test/test_spinsys.py
+++ b/test/test_spinsys.py
@@ -269,9 +269,6 @@ class TestSpinSystem(unittest.TestCase):
         evol_op_contribs = ssys.hamiltonian._calc_trotter_evol_op_contribs(1, True)
         self.assertEqual(len(evol_op_contribs), 2)
 
-        print(evol_op_contribs[0].indices)
-        print(evol_op_contribs[1].indices)
-
         self.assertTrue(
             np.all(
                 np.isclose(


### PR DESCRIPTION
Allows an intrinsic magnetic field to be defined using an `intrinsic_field` parameter. This is unaffected by rotations such as when angular averaging as suggested in #25. This PR also adds it to the docs.

Closes #25