### PR TITLE
Add compilation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,78 +3,10 @@
 MuSpinSim is a Python software meant to simulate muon spectroscopy experiments. In particular, it simulates the spin dynamics of a system of a muon plus other spins, namely electrons and atomic nuclei. It can simulate various common experimental setups and account for hyperfine, dipolar and quadrupolar couplings. It is also able to fit its simulations
 to experimental data, to find the optimal parameters that describe it.
 
-## Installation
-
-You can install the latest release using pip or conda:
-
-```bash
-pip install muspinsim
-conda install muspinsim
-```
-
-You may also install MuSpinSim from source which will require a C++ compiler to be present on the system. To do this obtain the source and install with
-
-```bash
-python setup.py install
-```
-
-This also allows you to install MuSpinSim with OpenMP support using the optional `--with-openmp` flag using
-
-```bash
-python setup.py install --with-openmp
-```
-
-This also requires that your compiler has OpenMP support.
-
-
-## Usage
-
-Once installed, the program will be made available for command line use as `muspinsim`. The usage is
-
-```bash
-muspinsim input_file.in
-```
-
-where the input file contains the parameters specifying the system and experiment details.
-
-For especially expensive calculations MuSpinSim can also be used in parallel with MPI. In that case, the running command is
-
-```bash
-mpirun -n <number of cores> muspinsim.mpi input_file.in
-```
-
-where `<number of cores>` is replaced by the number of desired cores on the given system.
-
-## Usage as a library
-
-MuSpinSim can also be used as a Python library within larger programs. The simplest way to do so is to use an input file to configure a problem, read it in with the `MuSpinInput` class, then use it to create a `MuonExperimentalSetup` that runs the actual experiment. The minimal script is:
-
-```python
-from muspinsim import MuSpinInput, ExperimentRunner
-
-params = MuSpinInput(open('input_file.in'))
-experiment = ExperimentRunner(params)
-
-results = experiment.run()
-```
-
-In order to instead run a fitting calculation, the minimal script is
-
-```python
-from muspinsim import MuSpinInput, FittingRunner
-
-params = MuSpinInput(open('input_file.in'))
-optimizer = FittingRunner(params)
-
-solution = optimizer.run()
-```
-
-For parallel use, it's recommended to stick to using the provided `muspinsim.mpi` script.
-
 ## Theory
 
 The way MuSpinSim operates is quite simple, and based on the principles of similar software for NMR, in particular [Simpson](https://pdfs.semanticscholar.org/c391/6ccc8f32ee3cad4820d73ecde101a268b9a3.pdf). A Hamiltonian of the system is built by combining the various terms specified in the input file; hyperfine, dipolar and quadrupolar terms are tied to the orientation of the 'crystallite' of the system we're observing, whereas muon polarization and applied external field are in an absolute reference frame (the one of the laboratory). The density matrix of the system is then made to evolve in time under this Hamiltonian, and the muon polarization is observed by standard quantum mechanical methods to compute expectation values. A slightly different approach is used when saving the integral of the expectation value, as in that case the integration is performed analytically to compute an "integral operator" whose expectation value is then computed. The biggest part of the computational load is tied to the diagonalization of the Hamiltonian, which is currently performed by using the library Numpy. This limits the usefulness of the program right now to matrices smaller than 1000x1000, corresponding roughly to ten spins with I=1/2. Bigger systems might take a while to run or run out of memory on personal computers.
 
-## Input files and other information
+## Installation and Usage
 
-For more in-depth information about how to use MuSpinSim and about how the theory behind it works, [please check the official documentation](https://muon-spectroscopy-computational-project.github.io/muspinsim/).
+For more in-depth information about how to install and use MuSpinSim as well as about how the theory behind it works, [please check the official documentation](https://muon-spectroscopy-computational-project.github.io/muspinsim/).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -12,18 +12,7 @@ muon science experiments. MuSpinSim can:
 
 ## How to install
 
-Download the latest version of the code from [Github](https://github.com/muon-spectroscopy-computational-project/muspinsim)
-and unzip it, then in the command line enter the folder and use `pip` to install it:
-
-```bash
-$> pip install ./
-```
-
-It can then be run from anywhere simply with
-
-```bash
-$> muspinsim input_file
-```
+Follow the installation instructions [here](./installation.md).
 
 ## Topics
 * Learn about the [theory of spin dynamics behind MuSpinSim](./theory_1.md);

--- a/docs/docs/input.md
+++ b/docs/docs/input.md
@@ -272,6 +272,7 @@ Two helper functions are provided to generate automatically ranges of orientatio
 | Allows expressions:   |              Yes |
 | Allows constants:     |          default |
 | Allows functions:     | default, `range` |
+
 *Example:*
 ```plaintext
 temperature
@@ -322,6 +323,7 @@ Block of data to fit. Must have two columns: the first one is the `x_axis` (for 
 | Allows expressions:   |               No |
 | Allows constants:     |              N/A |
 | Allows functions:     |              N/A |
+
 *Example:*
 ```plaintext
 fitting_method
@@ -374,7 +376,6 @@ A convenience keyword that sets a number of other parameters to reproduce certai
 | Allows constants:     |  Default |
 | Allows functions:     |  Default |
 
-
 *Example:*
 ```plaintext
 zeeman 1
@@ -409,6 +410,7 @@ Specify a hyperfine tensor, in MHz, for a given spin. A hyperfine tensor couples
 | Allows expressions:   |       Yes |
 | Allows constants:     |   Default |
 | Allows functions:     |   Default |
+
 *Example:*
 ```plaintext
 dipolar 1 2

--- a/docs/docs/input.md
+++ b/docs/docs/input.md
@@ -453,7 +453,8 @@ dissipation 1
 
 Add a dissipation term for a given spin, which switches the system to using the [Lindblad master equation](./theory_2.md#the-lindblad-master-equation) instead of regular unitary quantim evolution. The dissipative term will cause random spin flips that decohere the system and drive it towards a thermal equilibrium state (determined by the temperature). The dissipation term is given in MHz. Indices count from 1. 
 
-> **CAUTION:** Lindbladian matrices can be not diagonalizable. This functionality does not yet account for that, so it could fail in some cases.
+!!! warning
+    Lindbladian matrices can be not diagonalizable. This functionality does not yet account for that, so it could fail in some cases.
 
 ### celio
 | Keyword:              | `celio`       |
@@ -473,13 +474,15 @@ Use [Celio's Method](./theory_2.md#celios-method) instead of the regular time ev
 
 Larger values of $k$ are in theory more accurate but will become inaccurate again when very large at a point depending on the system. A value of $k = 0$ has no effect as it disables its use.
 
-> **NOTE:** Celio's method does not support [dissipation](#dissipation) or [integral](#y_axis) calculations.
+!!! note
+    Celio's method does not support [dissipation](#dissipation) or [integral](#y_axis) calculations.
 
 #### Method 1 - Evolving the density matrix
 
 When the number of averages is not specified or is given as 0, only the first part of Celio's method is performed to evolve the initial density matrix. This way it retains the ability to work with an initial temperature and is not subject to randomness in the results. This method will only provide a speed boost for certain systems, typically those with large spins and relatively few, simple interactions.
 
-> **CAUTION:** Some systems will be extremely slow using this method due to the matrix density being too high. A warning message is displayed in the '.log' file when this is the case.
+!!! warning
+    Some systems will be extremely slow using this method due to the matrix density being too high. A warning message is displayed in the '.log' file when this is the case.
 
 #### Method 2 - Using random initial states
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -1,0 +1,109 @@
+### Installing `muspinsim`
+
+In this tutorial we'll go through the best ways to install MuSpinSim on
+any system of your interest, so that you can use it for the other exercises.
+
+The first step is, of course, procuring Python itself. If you have not already
+done this, see the [tutorial here](./python-setup).
+
+#### Dependencies
+
+`pip` will take care of installing all of the dependencies (other packages
+that `muspinsim` needs to run). Just follow the instructions below.
+
+#### Installing MuSpinSim
+
+Granted that you already have Python and `pip` installed on your system, and a
+command line ready to use, then installing `muspinsim` is easy using
+
+```bash
+pip install muspinsim --user
+```
+or if you are using Anaconda, you may also use
+
+```bash
+conda install muspinsim
+```
+
+and you'll be ready to go.
+
+You do not need to worry about the details on the reset of this page unless the
+above failed, or you wish to install from the source.
+
+#### Installing from source
+
+To install from source you first need to ensure you have a suitable C++ compiler on
+your system. If you are on Linux or macOS, this is likely already the case, but for
+Windows you will likely need to install one such as [MSCV](https://visualstudio.microsoft.com/visual-cpp-build-tools/). 
+
+You obtain package source from GitHub in one of two ways. If you have `git` installed and are familiar with its
+use you can simply clone the repository:
+
+```bash
+git clone https://github.com/muon-spectroscopy-computational-project/muspinsim.git
+```
+
+Otherwise, you can download it as a 
+[zip file](https://github.com/muon-spectroscopy-computational-project/muspinsim/archive/main.zip)
+and unzip it in a folder of your choice.
+
+To install the downloaded source, navigate to the parent directory in your
+terminal. If you don't know how to do it,
+[here's a handy guide for Linux and MacOS](http://linuxcommand.org/lc3_lts0020.php).
+and [here's one for Windows](http://dosprompt.info/basics.asp), which has a 
+different syntax. 
+
+Once you are in the directory *above* the unzipped/cloned package, you can run:
+
+```bash
+pip install ./{package} --user
+```
+
+where `{package}` represents the name of the directory where you unzipped/cloned
+the package. In your case, if you didn't rename the unzipped directory, it should be:
+
+```bash
+pip install ./muspinsim --user
+```
+
+##### Compiling with OpenMP
+
+To compile with OpenMP to allow parallelisation you can assign the environment variable
+`MUSPINSIM_WITH_OPENMP` prior to installation. To do this on Linux and macOS you may use
+
+```bash
+export MUSPINSIM_WITH_OPENMP=1
+```
+
+and for Windows
+
+```bash
+set MUSPINSIM_WITH_OPENMP=1
+```
+
+!!! Important
+    While the default compiler on Linux, and most Windows compilers support OpenMP
+    the default compiler on macOS does not. As a result you should install a
+    compatible compiler first, see below.
+
+For macOS we recommend using clang from homebrew's llvm package. This can
+be installed via
+
+```bash
+brew install llvm
+```
+
+Then you need to the following environment variables to point to the
+the compilers from Homebrew's llvm package instead of the default. The paths may
+differ for your system but are usually
+
+```bash
+export CC="/usr/local/opt/llvm/bin/clang"
+export CXX="/usr/local/opt/llvm/bin/clang++"
+```
+
+With these variables set, install the downloaded source with
+
+```bash
+pip install ./muspinsim --user
+```

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -84,26 +84,24 @@ set MUSPINSIM_WITH_OPENMP=1
 !!! Important
     While the default compiler on Linux, and most Windows compilers support OpenMP
     the default compiler on macOS does not. As a result you should install a
-    compatible compiler first, see below.
+    compatible compiler first. We recommend using clang from homebrew's llvm
+    package which can be installed via
 
-For macOS we recommend using clang from homebrew's llvm package. This can
-be installed via
+    ```bash
+    brew install llvm
+    ```
 
-```bash
-brew install llvm
-```
+    Then you need to add the following environment variables to point to the
+    the new compilers instead of the default. The paths may differ for your
+    system but are usually
 
-Then you need to the following environment variables to point to the
-the compilers from Homebrew's llvm package instead of the default. The paths may
-differ for your system but are usually
+    ```bash
+    export CC="/usr/local/opt/llvm/bin/clang"
+    export CXX="/usr/local/opt/llvm/bin/clang++"
+    ```
 
-```bash
-export CC="/usr/local/opt/llvm/bin/clang"
-export CXX="/usr/local/opt/llvm/bin/clang++"
-```
+    With these set, you can now install the downloaded source with
 
-With these variables set, install the downloaded source with
-
-```bash
-pip install ./muspinsim --user
-```
+    ```bash
+    pip install ./muspinsim --user
+    ```

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -61,7 +61,7 @@ pip install ./muspinsim --user
 
 ##### Compiling with OpenMP
 
-If installing using `pip` or `conda`, then parallesisation with OpenMP will be enabled. If 
+If installing using `pip` or `conda`, then parallelisation with OpenMP will be enabled. If 
 compiling from source, to allow parallelisation you can assign the environment variable
 `MUSPINSIM_WITH_OPENMP` prior to installation. To do this on Linux and macOS you may use
 
@@ -99,3 +99,5 @@ set MUSPINSIM_WITH_OPENMP=1
     ```bash
     pip install ./muspinsim --user
     ```
+
+> **For developers:** You may also use `python setup.py --with-openmp build_ext --inplace` to compile the source with OpenMP while developing.

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -4,15 +4,10 @@ In this tutorial we'll go through the best ways to install MuSpinSim on
 any system of your interest. The first step is, of course, procuring Python
 itself. If you have not already done this, see the [tutorial here](https://muon-spectroscopy-computational-project.github.io/tutorial-folder/python-setup).
 
-#### Dependencies
-
-`pip` will take care of installing all of the dependencies (other packages
-that `muspinsim` needs to run). Just follow the instructions below.
-
 #### Installing with pip or conda
 
-Assuming you already have Python and `pip` installed on your system, and a
-command line ready to use, then installing `muspinsim` is easy using
+Using either `pip` or `conda` will take care of installing all of the dependencies (other packages
+that `muspinsim` needs to run). Assuming you already have Python and `pip` installed on your system, then installing `muspinsim` from the command line is easy using
 
 ```bash
 pip install muspinsim --user
@@ -66,7 +61,8 @@ pip install ./muspinsim --user
 
 ##### Compiling with OpenMP
 
-To compile with OpenMP to allow parallelisation you can assign the environment variable
+If installing using `pip` or `conda`, then parallesisation with OpenMP will be enabled. If 
+compiling from source, to allow parallelisation you can assign the environment variable
 `MUSPINSIM_WITH_OPENMP` prior to installation. To do this on Linux and macOS you may use
 
 ```bash

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -1,19 +1,17 @@
-### Installing `muspinsim`
+### Installing MuSpinSim
 
 In this tutorial we'll go through the best ways to install MuSpinSim on
-any system of your interest, so that you can use it for the other exercises.
-
-The first step is, of course, procuring Python itself. If you have not already
-done this, see the [tutorial here](./python-setup).
+any system of your interest. The first step is, of course, procuring Python
+itself. If you have not already done this, see the [tutorial here](https://muon-spectroscopy-computational-project.github.io/tutorial-folder/python-setup).
 
 #### Dependencies
 
 `pip` will take care of installing all of the dependencies (other packages
 that `muspinsim` needs to run). Just follow the instructions below.
 
-#### Installing MuSpinSim
+#### Installing with pip or conda
 
-Granted that you already have Python and `pip` installed on your system, and a
+Assuming you already have Python and `pip` installed on your system, and a
 command line ready to use, then installing `muspinsim` is easy using
 
 ```bash
@@ -36,8 +34,8 @@ To install from source you first need to ensure you have a suitable C++ compiler
 your system. If you are on Linux or macOS, this is likely already the case, but for
 Windows you will likely need to install one such as [MSCV](https://visualstudio.microsoft.com/visual-cpp-build-tools/). 
 
-You obtain package source from GitHub in one of two ways. If you have `git` installed and are familiar with its
-use you can simply clone the repository:
+After this you should obtain the source from GitHub in one of two ways. If you have
+`git` installed and are familiar with its use you can simply clone the repository:
 
 ```bash
 git clone https://github.com/muon-spectroscopy-computational-project/muspinsim.git
@@ -49,7 +47,7 @@ and unzip it in a folder of your choice.
 
 To install the downloaded source, navigate to the parent directory in your
 terminal. If you don't know how to do it,
-[here's a handy guide for Linux and MacOS](http://linuxcommand.org/lc3_lts0020.php).
+[here's a handy guide for Linux and MacOS](http://linuxcommand.org/lc3_lts0020.php)
 and [here's one for Windows](http://dosprompt.info/basics.asp), which has a 
 different syntax. 
 
@@ -82,7 +80,7 @@ set MUSPINSIM_WITH_OPENMP=1
 ```
 
 !!! Important
-    While the default compiler on Linux, and most Windows compilers support OpenMP
+    While the default compiler on Linux and most Windows compilers support OpenMP,
     the default compiler on macOS does not. As a result you should install a
     compatible compiler first. We recommend using clang from homebrew's llvm
     package which can be installed via

--- a/docs/docs/theory_1.md
+++ b/docs/docs/theory_1.md
@@ -424,7 +424,7 @@ S^e_x \\
 S^e_y \\ 
 S^e_z
 \end{bmatrix}
-= \\
+\\
  = & A_{xx}S^\mu_xS^e_x + A_{yy}S^\mu_yS^e_y + A_{zz}S^\mu_zS^e_z + \\
  +&A_{xy}(S^\mu_xS^e_y+S^\mu_yS^e_x) + A_{xz}(S^\mu_xS^e_z+S^\mu_zS^e_x) +  A_{yz}(S^\mu_yS^e_z+S^\mu_zS^e_y)
 \end{split}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -6,6 +6,9 @@ markdown_extensions:
   - pymdownx.arithmatex:
       generic: true
   - admonition
+  - pymdownx.superfences # Allows code block nesting in admonition
+  - pymdownx.highlight:
+      use_pygments: false # Avoids duplicate borders around blocks
 extra_javascript:
   - js/config.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -5,12 +5,14 @@ theme: readthedocs
 markdown_extensions:
   - pymdownx.arithmatex:
       generic: true
+  - admonition
 extra_javascript:
   - js/config.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 nav:
   - 'index.md'
+  - 'installation.md'
   - 'theory_1.md'
   - 'theory_2.md'
   - 'hamiltonian.md'


### PR DESCRIPTION
- Adds an installation page to the docs including information on compiling from source
- Enabled admonition and uses to make warnings and notes clearer on the examples page e.g.
![image](https://user-images.githubusercontent.com/90245114/212043235-ab9ac1aa-fcad-4992-ac05-c8bac210e1f4.png)

Notes
- The environment variable MUSPINSIM_OPENMP is added in #35 
- We recently added install docs here https://muon-spectroscopy-computational-project.github.io/tutorial-folder/installing-muspinsim, but this does not include info on compilation. I think we should either remove it and link to these new ones like the tutorials, or otherwise treat them separately as a simpler set of instructions without the compilation since the compilation info should be dependent on the muspinsim version

Closes #27