### PR TITLE
Update version to 2.0.0 and update CITATION.cff #38

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macOS-11 pinned here due to usage of $(brew --prefix llvm@14)
+        # macOS-11 pinned here due to usage of $(brew --prefix llvm@15)
         # macOS-12 will become macOS-latest in the near future but
         # is currently still unstable
         os: [ubuntu-latest, macOS-11, windows-latest]
@@ -40,10 +40,8 @@ jobs:
 
           # Default compiler on macOS doesn't support OpenMP, so force the usage
           # of homebrew's llvm see
-          # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
-          # Installing the latest (currently llvm 15.0.6) seems to skip the ARM OpenMP
-          # libraries meaning cross compilation fails)
-          CIBW_ENVIRONMENT_MACOS: CC="$(brew --prefix llvm@14)/bin/clang" CXX="$(brew --prefix llvm@14)/bin/clang++"
+          # https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md
+          CIBW_ENVIRONMENT_MACOS: CC="$(brew --prefix llvm@15)/bin/clang" CXX="$(brew --prefix llvm@15)/bin/clang++"
 
           # Run tests of the installed wheels (skipping ARM as they wont run here)
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macOS-12 pinned here due to usage of $(brew --prefix llvm@14) below
-        os: [ubuntu-latest, macOS-12, windows-latest]
+        # macOS-11 pinned here due to usage of $(brew --prefix llvm@14)
+        # macOS-12 will become macOS-latest in the near future but
+        # is currently still unstable
+        os: [ubuntu-latest, macOS-11, windows-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.10"]
-        # macOS-12 pinned here due to usage of $(brew --prefix llvm@14) below
-        os: [ubuntu-latest, macOS-12, windows-latest] # macOS-latest fails due to issue with OpenMP install
+        # macOS-11 pinned here due to usage of $(brew --prefix llvm@14)
+        # macOS-12 will become macOS-latest in the near future but
+        # is currently still unstable
+        os: [ubuntu-latest, macOS-11, windows-latest]
 
     steps:
     - uses: actions/checkout@v3
@@ -89,7 +91,7 @@ jobs:
 
     # Default compiler on macOS doesn't support OpenMP, so force the usage
     # of homebrew's llvm see
-    # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
+    # https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md
     - name: Add optional environment variables
       run: |
         if [ "$RUNNER_OS" == 'macOS' ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.10"]
-        # macOS-11 pinned here due to usage of $(brew --prefix llvm@14)
+        # macOS-11 pinned here due to usage of $(brew --prefix llvm@15)
         # macOS-12 will become macOS-latest in the near future but
         # is currently still unstable
         os: [ubuntu-latest, macOS-11, windows-latest]
@@ -95,8 +95,8 @@ jobs:
     - name: Add optional environment variables
       run: |
         if [ "$RUNNER_OS" == 'macOS' ]; then
-          echo "CC=$(brew --prefix llvm@14)/bin/clang" >> "$GITHUB_ENV"
-          echo "CXX=$(brew --prefix llvm@14)/bin/clang++" >> "$GITHUB_ENV"
+          echo "CC=$(brew --prefix llvm@15)/bin/clang" >> "$GITHUB_ENV"
+          echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> "$GITHUB_ENV"
         fi
       shell: bash
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,6 +26,14 @@ authors:
     family-names: Mudaraddi
     affiliation: Science and Technology Facilities Council
     orcid: 'https://orcid.org/0000-0002-2135-2705'
+  - given-names: Joel
+    family-names: Davies
+    affiliation: Science and Technology Facilities Council
+    orcid: 'https://orcid.org/0000-0002-4153-6819'
+  - given-names: John
+    family-names: Wilkinson
+    affiliation: Science and Technology Facilities Council
+    orcid: 'https://orcid.org/0000-0001-6879-7181'
   - name: "Muon Spectroscopy Computational Project"
 repository-code: >-
   https://github.com/muon-spectroscopy-computational-project/muspinsim
@@ -50,14 +58,14 @@ keywords:
   - "muon experiments: zero field"
 license: MIT
 # version data
-version: v2.0.0.dev0
-date-released: '2022-08-26'
+version: v2.0.0
+date-released: '2023-01-30'
 identifiers:
   - type: doi
     value: 10.5281/zenodo.6517626
     description: The concept DOI for the collection containing all versions of muspinsim.
   - type: doi
-    value: 10.5281/zenodo.6563074
-    description: The versioned DOI for the version 1.1.0 of muspinsim.
+    value: 10.5281/zenodo.7026020
+    description: The versioned DOI for the version 1.2.0 of muspinsim.
 # references - to come!
 # references:

--- a/muspinsim/version.py
+++ b/muspinsim/version.py
@@ -2,4 +2,4 @@
 
 Version of the package. Kept separated to allow for import from setup.py"""
 
-__version__ = "2.0.0.dev1"
+__version__ = "2.0.0"


### PR DESCRIPTION
Update ready for release

Actual doi for 2.0.0 will need to be force updated later as per step 5 in https://github.com/muon-spectroscopy-computational-project/Developer-notes/blob/main/package-maintenance.md.

MacOS runner images were also updated yesterday and have replaced llvm@14 with 15 but even after updating fails for python 3.10 so updated to pin to macOS-11 as macOS-12 appears unstable at least until proper release on the 1st of March.