### PR TITLE
Fix missing files from source distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,12 @@ jobs:
         run: |
           python -m pip install build
           python -m build --sdist
+        # Ensure source distribution is actually buildable (in case any files are missing)
+      - name: Test sdist
+        run: |
+          mkdir ./muspinsim-sdist
+          tar -xf ./dist/muspinsim-*.tar.gz -C ./muspinsim-sdist --strip-components 1
+          pip install ./muspinsim-sdist
       - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -58,8 +58,8 @@ keywords:
   - "muon experiments: zero field"
 license: MIT
 # version data
-version: v2.0.0
-date-released: '2023-01-23'
+version: v2.0.1
+date-released: '2023-01-24'
 identifiers:
   - type: doi
     value: 10.5281/zenodo.6517626

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+recursive-include muspinsim *.pyx
+recursive-include muspinsim *.pxd
+recursive-include muspinsim *.hpp
+recursive-include muspinsim *.cpp
+recursive-include muspinsim *.h

--- a/muspinsim/version.py
+++ b/muspinsim/version.py
@@ -2,4 +2,4 @@
 
 Version of the package. Kept separated to allow for import from setup.py"""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"


### PR DESCRIPTION
Turns out header files are ignored when building the source distribution, this creates a minor release 2.0.1 fixing this and adds a test to the sdist build to hopefully avoid any similar issues in the future.