### PR TITLE
Fix mpirun errors #42

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -58,8 +58,8 @@ keywords:
   - "muon experiments: zero field"
 license: MIT
 # version data
-version: v2.0.1
-date-released: '2023-01-24'
+version: v2.0.2
+date-released: '2023-01-25'
 identifiers:
   - type: doi
     value: 10.5281/zenodo.6517626

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -110,14 +110,12 @@ def main(use_mpi=False):
             force=True,
         )
 
-        logging.info(
-            "Launching MuSpinSim calculation from file: %s", inp_filepath
-        )
+        logging.info("Launching MuSpinSim calculation from file: %s", inp_filepath)
 
         if is_fitting:
             logging.info(
                 "Performing fitting in variables: %s",
-                ", ".join(infile.variables)
+                ", ".join(infile.variables),
             )
 
         tstart = datetime.now()

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -28,8 +28,8 @@ def ensure_dir_path_exists(path_string):
     if not os.path.isdir(path_string):
         try:
             os.makedirs(path_string)
-        except OSError:
-            raise NotADirectoryError(path_string)
+        except OSError as exc:
+            raise NotADirectoryError(path_string) from exc
     return path_string
 
 
@@ -80,9 +80,13 @@ def main(use_mpi=False):
         inp_file_name = os.path.basename(inp_filepath).split(".")[0]
         inp_dir = os.path.dirname(inp_filepath)
 
-        fs = open(inp_filepath)
+        fs = open(inp_filepath, encoding="utf-8")
         infile = MuSpinInput(fs)
         is_fitting = len(infile.variables) > 0
+
+        out_path = inp_dir
+        if args.out_dir:
+            out_path = ensure_dir_path_exists(args.out_dir)
 
         # Open logfile
         logfile = os.path.join(inp_dir, inp_file_name + ".log")
@@ -107,13 +111,13 @@ def main(use_mpi=False):
         )
 
         logging.info(
-            "Launching MuSpinSim calculation from file: {0}".format(inp_filepath)
+            "Launching MuSpinSim calculation from file: %s", inp_filepath
         )
 
         if is_fitting:
             logging.info(
-                "Performing fitting in variables: "
-                "{0}".format(", ".join(infile.variables))
+                "Performing fitting in variables: %s",
+                ", ".join(infile.variables)
             )
 
         tstart = datetime.now()
@@ -122,10 +126,6 @@ def main(use_mpi=False):
         is_fitting = False
 
     is_fitting = mpi.broadcast(is_fitting)
-
-    out_path = inp_dir
-    if args.out_dir:
-        out_path = ensure_dir_path_exists(args.out_dir)
 
     if not is_fitting:
         # No fitting
@@ -141,7 +141,7 @@ def main(use_mpi=False):
 
         if mpi.is_root:
             rep_dname = inp_dir
-            rep_fname = "{0}_fit_report.txt".format(inp_file_name)
+            rep_fname = f"{inp_file_name}_fit_report.txt"
             if args.fit_report_path:
                 try:
                     # check if directory exists, if not create it

--- a/muspinsim/mpi.py
+++ b/muspinsim/mpi.py
@@ -73,10 +73,8 @@ class MPIController(object):
             v = obj.__dict__.get(k, None)
             try:
                 v = self.comm.bcast(v, root=0)
-            except OverflowError as e:
-                raise OverflowError(
-                    "Overflow error on: {0}, {1}: {2}".format(k, v, str(e))
-                )
+            except OverflowError as exc:
+                raise OverflowError(f"Overflow error on: {k}, {v}: {str(exc)}") from exc
             obj.__setattr__(k, v)
 
     def broadcast_terms(self, lst):
@@ -98,10 +96,10 @@ class MPIController(object):
 
             try:
                 val = self.comm.bcast(val, root=0)
-            except OverflowError as e:
+            except OverflowError as exc:
                 raise OverflowError(
-                    "Overflow error broadcasting term {0}: {1}".format(val, str(e))
-                )
+                    f"Overflow error broadcasting term {val}: {str(exc)}"
+                ) from exc
             n_list.append(val)
         return n_list
 

--- a/muspinsim/mpi.py
+++ b/muspinsim/mpi.py
@@ -74,7 +74,7 @@ class MPIController(object):
             try:
                 v = self.comm.bcast(v, root=0)
             except OverflowError as exc:
-                raise OverflowError(f"Overflow error on: {k}, {v}: {str(exc)}") from exc
+                raise OverflowError(f"Overflow error on: {k}, {v}") from exc
             obj.__setattr__(k, v)
 
     def broadcast_terms(self, lst):
@@ -97,9 +97,7 @@ class MPIController(object):
             try:
                 val = self.comm.bcast(val, root=0)
             except OverflowError as exc:
-                raise OverflowError(
-                    f"Overflow error broadcasting term {val}: {str(exc)}"
-                ) from exc
+                raise OverflowError(f"Overflow error broadcasting term {val}") from exc
             n_list.append(val)
         return n_list
 

--- a/muspinsim/tests/test_args.py
+++ b/muspinsim/tests/test_args.py
@@ -11,11 +11,11 @@ def set_sys_argv(vals):
     sys.argv[1:] = vals
 
 
-def run_experiment(inp_string, inp_file_path, cmd_args):
-    with open(inp_file_path, "w") as f:
+def run_experiment(inp_string, inp_file_path, cmd_args, use_mpi=False):
+    with open(inp_file_path, "w", encoding="utf-8") as f:
         f.write(inp_string)
     set_sys_argv([inp_file_path] + cmd_args)
-    main()
+    main(use_mpi=use_mpi)
 
 
 class TestCommandLineArgs(unittest.TestCase):
@@ -26,7 +26,7 @@ class TestCommandLineArgs(unittest.TestCase):
         # default again and print to stdout to avoid FileNotFound errors
         logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, force=True)
 
-    def test_main_default_args(self):
+    def _main_default_args(self, use_mpi):
         with tempfile.TemporaryDirectory() as tmp_dir:
             cmd_args = []
             inp_file_path = os.path.join(tmp_dir, "custom_args.in")
@@ -41,12 +41,19 @@ zeeman 1
 """,
                 inp_file_path,
                 cmd_args,
+                use_mpi=use_mpi,
             )
 
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, "custom_args.log")))
-            self.assertTrue(os.path.exists("{0}/test_1.dat".format(tmp_dir)))
+            self.assertTrue(os.path.exists(f"{tmp_dir}/test_1.dat"))
 
-    def test_main_custom_args(self):
+    def test_main_default_args(self):
+        self._main_default_args(False)
+
+    def test_main_default_args_mpi(self):
+        self._main_default_args(True)
+
+    def _main_custom_args(self, use_mpi):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with tempfile.TemporaryDirectory() as out_tmp_dir:
                 cmd_args = [
@@ -67,6 +74,7 @@ zeeman 1
 """,
                     inp_file_path,
                     cmd_args,
+                    use_mpi=use_mpi,
                 )
 
                 self.assertTrue(
@@ -74,7 +82,13 @@ zeeman 1
                 )
                 self.assertTrue(os.path.exists(os.path.join(out_tmp_dir, "test_2.dat")))
 
-    def test_main_fitting_default_args(self):
+    def test_main_custom_args(self):
+        self._main_custom_args(False)
+
+    def test_main_custom_args_mpi(self):
+        self._main_custom_args(True)
+
+    def _main_fitting_default_args(self, use_mpi):
         with tempfile.TemporaryDirectory() as tmp_dir:
             cmd_args = []
             inp_file_path = os.path.join(tmp_dir, "fitting_default_args.in")
@@ -96,6 +110,7 @@ dissipation 1
 """,
                 inp_file_path,
                 cmd_args,
+                use_mpi=use_mpi,
             )
 
             self.assertTrue(
@@ -108,7 +123,13 @@ dissipation 1
                 )
             )
 
-    def test_main_filenames_as_input(self):
+    def test_main_fitting_default_args(self):
+        self._main_fitting_default_args(False)
+
+    def test_main_fitting_default_args_mpi(self):
+        self._main_fitting_default_args(True)
+
+    def _main_filenames_as_input(self, use_mpi):
         with tempfile.TemporaryDirectory() as tmp_dir:
             cmd_args = ["-l", "new_test.log", "-f", "new_fit_report.txt"]
             inp_file_path = os.path.join(tmp_dir, "fitting_default_args.in")
@@ -130,13 +151,20 @@ dissipation 1
 """,
                 inp_file_path,
                 cmd_args,
+                use_mpi=use_mpi,
             )
 
-            self.assertTrue(os.path.exists("{0}/new_test.log".format(tmp_dir)))
-            self.assertTrue(os.path.exists("{0}/test_fitting.dat".format(tmp_dir)))
-            self.assertTrue(os.path.exists("{0}/new_fit_report.txt".format(tmp_dir)))
+            self.assertTrue(os.path.exists(f"{tmp_dir}/new_test.log"))
+            self.assertTrue(os.path.exists(f"{tmp_dir}/test_fitting.dat"))
+            self.assertTrue(os.path.exists(f"{tmp_dir}/new_fit_report.txt"))
 
-    def test_main_fitting_custom_args(self):
+    def test_main_filenames_as_input(self):
+        self._main_filenames_as_input(False)
+
+    def test_main_filenames_as_input_mpi(self):
+        self._main_filenames_as_input(True)
+
+    def _main_fitting_custom_args(self, use_mpi):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with tempfile.TemporaryDirectory() as out_tmp_dir:
                 cmd_args = [
@@ -166,6 +194,7 @@ dissipation 1
 """,
                     inp_file_path,
                     cmd_args,
+                    use_mpi=use_mpi,
                 )
 
                 self.assertTrue(
@@ -177,3 +206,9 @@ dissipation 1
                 self.assertTrue(
                     os.path.exists(os.path.join(out_tmp_dir, "new_fit_report.txt"))
                 )
+
+    def test_main_fitting_custom_args(self):
+        self._main_fitting_custom_args(False)
+
+    def test_main_fitting_custom_args_mpi(self):
+        self._main_fitting_custom_args(True)

--- a/muspinsim/version.py
+++ b/muspinsim/version.py
@@ -2,4 +2,4 @@
 
 Version of the package. Kept separated to allow for import from setup.py"""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"


### PR DESCRIPTION
Fixes issue when using mpirun as there was an assignment outside of the main thread requiring a variable only assigned within it. Also fixes some linting warnings I came across and adds more unit tests to cover the errors as they were missing before.

Closes #42