### PR TITLE
Further memory reduction for Celio's #48

### DIFF
--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -77,13 +77,15 @@ class ExperimentRunner(object):
         self._config = config
         self._system = config.system
 
-        # Store single spin operators
-        self._single_spinops = np.array(
-            [
-                [self._system.operator({i: a}).matrix for a in "xyz"]
-                for i in range(len(self._system))
-            ]
-        )
+        # Store single spin operators (only needed for dispersion
+        # and non other non celio methods)
+        if not self.config.celio_k:
+            self._single_spinops = np.array(
+                [
+                    [self._system.operator({i: a}).matrix for a in "xyz"]
+                    for i in range(len(self._system))
+                ]
+            )
 
         # Parameters
         self._B = np.zeros(3)

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -402,9 +402,6 @@ class ExperimentRunner(object):
 
         w = self.load_config(cfg_snap)
 
-        # Measurement operator?
-        S = self.p_operator
-
         H = self.Htot
 
         if cfg_snap.y == "asymmetry":
@@ -425,6 +422,9 @@ class ExperimentRunner(object):
                     True,
                 )
             else:
+                # Measurement operator
+                S = self.p_operator
+
                 # Use faster evolution if able to (Doesn't exist for Linbladian)
                 if self._T_inf_speedup and not isinstance(H, Lindbladian):
                     other_spins = list(range(0, len(self._system.spins)))
@@ -439,6 +439,9 @@ class ExperimentRunner(object):
                 else:
                     data = H.evolve(self.rho0, cfg_snap.t, operators=[S])[:, 0]
         elif cfg_snap.y == "integral":
+            # Measurement operator
+            S = self.p_operator
+
             data = H.integrate_decaying(self.rho0, MU_TAU, operators=[S])[0] / MU_TAU
 
         return np.real(data) * w

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -245,6 +245,11 @@ class ExperimentRunner(object):
 
     @property
     def dissipation_operators(self):
+        if self._config.celio_k:
+            raise NotImplementedError(
+                "Dissipation is not supported when using Celio's method"
+            )
+
         if self._dops is None:
 
             # Create a copy of the system

--- a/muspinsim/spinsys.py
+++ b/muspinsim/spinsys.py
@@ -656,8 +656,8 @@ class MuonSpinSystem(SpinSystem):
         self._mu_i = self._spins.index("mu")
         self._e_i = set([i for i, s in enumerate(self.spins) if s == "e"])
 
-        # For convenience, store the operators for the muon
-        self._mu_ops = [self.operator({self._mu_i: e}) for e in "xyz"]
+        # Define only when needed (not needed for Celio's)
+        self._mu_ops = None
 
     @property
     def muon_index(self):
@@ -725,6 +725,12 @@ class MuonSpinSystem(SpinSystem):
 
         if len(v) != 3:
             raise ValueError("Vector passed to muon_operator must be three dimensional")
+
+        # Compute and store muon operators (for Celio's this method will not be called
+        # at all, but other times it may be called more than once and we dont want to
+        # recalculate all of the operators each time)
+        if self._mu_ops is None:
+            self._mu_ops = [self.operator({self._mu_i: e}) for e in "xyz"]
 
         op = [x * self._mu_ops[i] for i, x in enumerate(v)]
         op = sum(op[1:], op[0])

--- a/muspinsim/tests/test_experiment.py
+++ b/muspinsim/tests/test_experiment.py
@@ -270,6 +270,27 @@ celio
         with self.assertRaises(ValueError):
             results = ertest.run()
 
+        # Simple system that should fail as has dissipation
+        stest = StringIO(
+            """
+spins
+    e mu
+time
+    range(0, 10)
+zeeman 2
+    0 0 1.0/muon_gyr
+celio
+    10
+dissipation 1
+    0.5
+"""
+        )
+        itest = MuSpinInput(stest)
+        ertest = ExperimentRunner(itest)
+
+        with self.assertRaises(NotImplementedError):
+            results = ertest.run()
+
         # Simple system
         stest = StringIO(
             """


### PR DESCRIPTION
During testing 7+ 7/2 spins I discovered the memory usage was higher than I expected. Turns out muspinsim was still pre-calculating large matrices that were never used in Celio's method. I have now modified it to stop this, reducing memory usage by a further factor of 8 in this case.

Closes #48 