### PR TITLE
Add cell file tool #50

### DIFF
--- a/muspinsim/input/gipaw.py
+++ b/muspinsim/input/gipaw.py
@@ -104,7 +104,7 @@ class GIPAWOutput:
             if identifier is None:
                 identifier = current_identifier
                 index = current_index
-            elif current_identifier != identifier or current_index != current_index:
+            elif current_identifier != identifier or current_index != index:
                 raise ValueError("Error while parsing EFG")
 
             efg_tensor[i, 0] = float(split[2])
@@ -126,7 +126,7 @@ class GIPAWOutput:
             ArrayLike | None -- EFG tensor or None if not found
         """
         # Check if at index (faster)
-        if self._atoms[index - 1].index == index:
+        if index < len(self._atoms) and self._atoms[index - 1].index == index:
             return self._atoms[index - 1]
 
         found_atoms = list(

--- a/muspinsim/input/gipaw.py
+++ b/muspinsim/input/gipaw.py
@@ -22,7 +22,7 @@ class GIPAWOutput:
     work.
     """
 
-    _atoms: List[GIPAWAtom] = []
+    _atoms: List[GIPAWAtom]
 
     def __init__(self, file_io: Union[str, IO]):
         """Load a file containing output from GIPAW
@@ -32,6 +32,8 @@ class GIPAWOutput:
         Arguments:
             file_io {TextIOBase} -- File path, or IO stream
         """
+
+        self._atoms = []
 
         if isinstance(file_io, str):
             file_io = open(file_io, encoding="utf_8")

--- a/muspinsim/input/gipaw.py
+++ b/muspinsim/input/gipaw.py
@@ -1,0 +1,115 @@
+from dataclasses import dataclass
+import re
+from typing import IO, List, Optional, Union
+from numpy.typing import ArrayLike
+import numpy as np
+
+
+@dataclass
+class GIPAW_EFG:
+    """
+    Stores data for an EFG tensor entry
+    """
+
+    index: int
+    tensor: ArrayLike
+
+
+class GIPAWOutput:
+    """
+    Parses the output of a GIPAW execution. Currently made specifically
+    for parsing the results of an EFG calculation. No guarantees this will
+    work.
+    """
+
+    _atom_efgs: List[GIPAW_EFG] = []
+
+    def __init__(self, file_io: Union[str, IO]):
+        """Load a file containing output from GIPAW
+
+        Reads in EFG tensors from the file.
+
+        Arguments:
+            file_io {TextIOBase} -- File path, or IO stream
+        """
+
+        if isinstance(file_io, str):
+            file_io = open(file_io, encoding="utf_8")
+
+        # Attempt to skip to relevant part of the file
+        while not file_io.readline().strip().startswith("----- total EFG -----"):
+            continue
+
+        loop = True
+        while loop:
+            # Should be 3 lines at a time per element e.g.
+            #      V    1       -0.008879        0.000000       -0.011803
+            #      V    1        0.000000       -0.030597        0.000000
+            #      V    1       -0.011803        0.000000        0.039476
+
+            lines = [
+                file_io.readline().strip(),
+                file_io.readline().strip(),
+                file_io.readline().strip(),
+            ]
+
+            atom_efg = self._parse_efg(lines)
+            if atom_efg is not None:
+                self._atom_efgs.append(atom_efg)
+            else:
+                loop = False
+
+            # Go to the next line
+            file_io.readline()
+
+        file_io.close()
+
+    def _parse_efg(self, lines: List[str]) -> Optional[GIPAW_EFG]:
+        """Parse an EFG tensor given the 3 lines that represent it e.g.
+
+        V    1       -0.008879        0.000000       -0.011803
+        V    1        0.000000       -0.030597        0.000000
+        V    1       -0.011803        0.000000        0.039476
+
+        Arguments:
+            lines {List[str]} -- Lines representing the above.
+        Returns:
+            GIPAW_EFG | None -- Structure containing the EFG tensor or None
+                                in the case parsing failed and its likely we
+                                are at the end of that section.
+        Raises:
+            ValueError -- When the lines have different indices or symbols.
+                          Modifies indices to start from 0 instead of 1.
+        """
+
+        identifier = None
+        index = None
+        efg_tensor = np.zeros((3, 3))
+
+        for i in range(0, 3):
+            # Split by at least one space
+            split = re.split(r"\s{1,}", lines[i])
+
+            # Return None when invalid i.e. likely finished the section describing
+            # the EFG tensors
+            if len(split) != 5:
+                return None
+
+            current_identifier = split[0]
+            try:
+                current_index = int(split[1])
+            except ValueError:
+                return None
+
+            if identifier is None:
+                identifier = current_identifier
+                index = current_index
+            elif current_identifier != identifier or current_index != current_index:
+                raise ValueError("Error while parsing EFG")
+
+            efg_tensor[i, 0] = float(split[2])
+            efg_tensor[i, 1] = float(split[3])
+            efg_tensor[i, 2] = float(split[4])
+
+        # Start indices from 0
+        return GIPAW_EFG(index=index - 1, tensor=efg_tensor)

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -12,7 +12,7 @@ class CellAtom:
     Dataclass storing information about an atom in a cell structure
     """
 
-    index: int  # Unchanged when creating a supercell
+    index: int  # Start from 1, unchanged when creating a supercell
     symbol: str
     position: ArrayLike
     vector_from_muon: Optional[ArrayLike] = None
@@ -79,7 +79,7 @@ class MuonatedStructure:
         # Store only needed data for calculations
         for i, loaded_atom in enumerate(loaded_atoms):
             if loaded_atom.symbol == muon_symbol:
-                if muon_symbol is None:
+                if self._muon_index is None:
                     self._muon_index = i
                 else:
                     raise ValueError(
@@ -87,7 +87,7 @@ class MuonatedStructure:
                         f"with symbol {muon_symbol}"
                     )
 
-            self._atoms[i] = CellAtom(i, loaded_atom.symbol, loaded_atom.position)
+            self._atoms[i] = CellAtom(i + 1, loaded_atom.symbol, loaded_atom.position)
 
         if self._muon_index is None:
             raise ValueError(

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -297,7 +297,7 @@ class MuonatedStructure:
             "Attempting to find the %s closest atoms to the muon in " "the structure",
             number,
         )
-        if not ignored_symbols is None:
+        if ignored_symbols is not None:
             logging.info("Ignoring the symbols %s", ", ".join(ignored_symbols))
 
         while continue_expansion:

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -201,7 +201,7 @@ class MuonatedStructure:
         # Compute combinations
         offsets = []
 
-        # Hold z fixed at one of the extreme values and vary others
+        # Hold x fixed at one of the extreme values and vary others
         for x_value in extreme_values[0]:
             for y_value in potential_values[1]:
                 for z_value in potential_values[2]:
@@ -234,7 +234,7 @@ class MuonatedStructure:
                            along the x, y and z axes so that returned atoms
                            will have been computed for the 26 surrounding
                            cells. layer = 2 will then add compute those in
-                           the next layer, which will include 96 cells etc.
+                           the next layer, which will include 98 cells etc.
             ignored_symbols {List[str]} -- List of symbols to ignore. May be
                                            None.
         Returns:

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -80,9 +80,9 @@ class MuonatedStructure:
         """
 
         # Load the atomic data from the file
-        # NOTE: Calculator is loaded automatically - cant see a way to disable
-        # but this will cause warnings when reading CASTEP files without
-        # a CASTEP installation - these can be ignored
+        # NOTE: Calculator is loaded automatically - can't see a way to
+        # disable but this will cause warnings when reading CASTEP files
+        # without a CASTEP installation - these can be ignored
         loaded_atoms = ase.io.read(file_io, format=fmt)
 
         lengths_and_angles = loaded_atoms.get_cell_lengths_and_angles()

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -174,22 +174,12 @@ class MuonatedStructure:
         """
 
         # Construct the offsets
-        x_values = np.arange(
-            -layers * self._unit_lengths[0],
-            (layers + 1) * self._unit_lengths[0],
-            self._unit_lengths[0],
-        )
-        y_values = np.arange(
-            -layers * self._unit_lengths[1],
-            (layers + 1) * self._unit_lengths[1],
-            self._unit_lengths[1],
-        )
-        z_values = np.arange(
-            -layers * self._unit_lengths[2],
-            (layers + 1) * self._unit_lengths[2],
-            self._unit_lengths[2],
-        )
-        offsets = np.array(np.meshgrid(x_values, y_values, z_values)).T.reshape(-1, 3)
+        values = [np.arange(
+            -layers * self._unit_lengths[i],
+            (layers + 1) * self._unit_lengths[i],
+            self._unit_lengths[i],
+        ) for i in range(3)]
+        offsets = np.array(np.meshgrid(*values)).T.reshape(-1, 3)
         # Remove 0, 0, 0
         offsets = np.delete(offsets, int(np.floor(len(offsets) / 2)), axis=0)
 
@@ -198,8 +188,6 @@ class MuonatedStructure:
 
     def compute_distances(self):
         """Computes the vectors and distances between the muon and every atom.
-
-        Computes the vectors and distances between the muon and every atom.
         """
         muon = self._atoms[self._muon_index]
 

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import logging
 import math
 from pathlib import PurePath
 from typing import IO, List, Optional, Union
@@ -292,11 +293,20 @@ class MuonatedStructure:
         continue_expansion = True
         layer = 1
 
+        logging.info(
+            "Attempting to find the %s closest atoms to the muon in " "the structure",
+            number,
+        )
+        if not ignored_symbols is None:
+            logging.info("Ignoring the symbols %s", ", ".join(ignored_symbols))
+
         while continue_expansion:
             # Sort by distance and obtain furthest distance of the desired
             # atom
             atoms = sorted(atoms, key=lambda atom: atom.distance_from_muon)
             furthest_atom = atoms[min(number, len(atoms) - 1)]
+
+            logging.info("Expanding structure to layer: %d", layer)
 
             # Compute another layer and find the closest
             new_atoms = self.compute_layer(layer, ignored_symbols)
@@ -324,8 +334,17 @@ class MuonatedStructure:
                 # No more expansion needed
                 continue_expansion = False
 
-        # Return closest 'number' atoms (ignoring the muon itself)
-        return atoms[1 : (number + 1)]
+        # Ignore the muon and obtain only the atoms requested
+        atoms = atoms[1 : (number + 1)]
+
+        for atom in atoms:
+            logging.info(
+                "Found %s at a distance of %s from the muon",
+                atom.symbol,
+                atom.distance_from_muon,
+            )
+
+        return atoms
 
     @property
     def symbols_zero_spin(self) -> List[str]:

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -253,7 +253,10 @@ class MuonatedStructure:
             atom.distance_from_muon = np.linalg.norm(atom.vector_from_muon)
 
     def compute_closest(
-        self, number: int, ignored_symbols: Optional[List[str]] = None
+        self,
+        number: int,
+        ignored_symbols: Optional[List[str]] = None,
+        max_layer: int = 6,
     ) -> List[CellAtom]:
         """Returns atoms the closest 'number' atoms to the muon.
 
@@ -266,10 +269,16 @@ class MuonatedStructure:
                             available.
             ignored_symbols {List[str]} -- List of symbols to ignore. May be
                                            None.
+            max_layer {int} -- Maximum layer to allow the expansion to (for
+                               avoiding any accidental long compute times)
 
         Returns:
             List[CellAtom] -- List of the found closest atoms to the muon
                               (ignoring any in ignored_symbols)
+
+        Raises:
+            RuntimeError -- When the expansion tries to go beyond the maximum
+                            limit given by max_layer.
         """
 
         # Current list of atoms in expanded supercell
@@ -307,6 +316,10 @@ class MuonatedStructure:
                 atoms.extend(new_atoms)
 
                 layer += 1
+
+                # Avoid taking forever
+                if layer > max_layer:
+                    raise RuntimeError("Trying to expand past the max_layer value")
             else:
                 # No more expansion needed
                 continue_expansion = False

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -12,7 +12,7 @@ class CellAtom:
     Dataclass storing information about an atom in a cell structure
     """
 
-    index: int  # Index is unchanged when creating a supercell
+    index: int  # Unchanged when creating a supercell
     symbol: str
     position: ArrayLike
     vector_from_muon: Optional[ArrayLike] = None
@@ -51,6 +51,8 @@ class MuonatedStructure:
         Raises:
             ValueError -- If the structure file has unit cell vector angles
                           different from [90, 90, 90].
+            ValueError -- If the structure file contains more than one muon
+                          with the given symbol.
             ValueError -- If the structure file has no muon with the given
                           symbol.
         """
@@ -77,7 +79,13 @@ class MuonatedStructure:
         # Store only needed data for calculations
         for i, loaded_atom in enumerate(loaded_atoms):
             if loaded_atom.symbol == muon_symbol:
-                self._muon_index = i
+                if muon_symbol is None:
+                    self._muon_index = i
+                else:
+                    raise ValueError(
+                        f"Structure file '{file_io}' has more than one muon "
+                        f"with symbol {muon_symbol}"
+                    )
 
             self._atoms[i] = CellAtom(i, loaded_atom.symbol, loaded_atom.position)
 

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -27,13 +27,16 @@ def _get_isotope(mass: float, default_mass: float) -> int:
     """
     Helper function to determine the isotope by comparing the found mass to
     the default of the same element
+
+    At the moment will not return anything other than 1 as there is no where
+    to get the isotope masses from.
     """
 
     # Expect close to whole division if valid
-    if not math.isclose(mass % default_mass, 0):
+    if not math.isclose(mass, default_mass):
         raise ValueError("Failed to identify isotope by the given masses")
 
-    return int(mass // default_mass)
+    return 1
 
 
 class MuonatedStructure:

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -48,11 +48,11 @@ class MuonatedStructure:
     # Loaded data
     _unit_lengths: ArrayLike
     _unit_angles: ArrayLike
-    _cell_atoms: List[CellAtom] = []
+    _cell_atoms: List[CellAtom]
 
-    _muon_index: int = None
+    _muon_index: int
 
-    _symbols_zero_spin: List[str] = []
+    _symbols_zero_spin: List[str]
 
     def __init__(
         self,
@@ -79,6 +79,10 @@ class MuonatedStructure:
             ValueError -- If the structure file has no muon with the given
                           symbol.
         """
+
+        self._cell_atoms = []
+        self._muon_index = None
+        self._symbols_zero_spin = []
 
         # Load the atomic data from the file
         # NOTE: Calculator is loaded automatically - can't see a way to
@@ -280,18 +284,16 @@ class MuonatedStructure:
         layer = 1
 
         while continue_expansion:
-            # Sort by distance
+            # Sort by distance and obtain furthest distance of the desired
+            # atom
             atoms = sorted(atoms, key=lambda atom: atom.distance_from_muon)
-
-            # Obtain furthest distance of desired atom
             furthest_atom = atoms[min(number, len(atoms) - 1)]
 
-            # Compute another layer and sort those
+            # Compute another layer and find the closest
             new_atoms = self.compute_layer(layer, ignored_symbols)
             self._compute_distances(new_atoms)
             new_atoms = sorted(new_atoms, key=lambda atom: atom.distance_from_muon)
 
-            # Check if we need to include the new ones
             closest_new_atom = new_atoms[0]
 
             # Check whether we have just found atoms closer than the furthest

--- a/muspinsim/input/structure/structure.py
+++ b/muspinsim/input/structure/structure.py
@@ -1,0 +1,225 @@
+from dataclasses import dataclass
+from pathlib import PurePath
+from typing import IO, List, Optional, Union
+import numpy as np
+import ase.io
+from numpy.typing import ArrayLike
+
+
+@dataclass
+class CellAtom:
+    """
+    Dataclass storing information about an atom in a cell structure
+    """
+
+    index: int  # Index is unchanged when creating a supercell
+    symbol: str
+    position: ArrayLike
+    vector_from_muon: Optional[ArrayLike] = None
+    distance_from_muon: Optional[float] = None
+
+
+class MuonatedStructure:
+    """
+    A class for handling data from a muonated structure file and computing
+    distances between the atoms
+    """
+
+    # Loaded data
+    _unit_lengths: ArrayLike
+    _unit_angles: ArrayLike
+    _atoms: List[CellAtom] = []
+    _muon_index: int = None
+
+    def __init__(
+        self,
+        file_io: Union[str, PurePath, IO],
+        fmt: Union[str, None] = None,
+        muon_symbol: Union[str, int] = "H",
+    ):
+        """Load a muonated cell structure file
+
+        Read in a cell structure from an opened file stream
+
+        Arguments:
+            file_io {TextIOBase} -- File path, or IO stream
+            fmt {str} -- Format of the file/data. See ase documentation for
+                         available ones. When None ase will attempt to
+                         determine it.
+            muon_symbol {str} -- Symbol that should represent a muon.
+
+        Raises:
+            ValueError -- If the structure file has unit cell vector angles
+                          different from [90, 90, 90].
+            ValueError -- If the structure file has no muon with the given
+                          symbol.
+        """
+
+        # Load the atomic data from the file
+        # NOTE: Calculator is loaded automatically - cant see a way to disable
+        # but this will cause warnings when reading CASTEP files without
+        # a CASTEP installation - these can be ignored
+        loaded_atoms = ase.io.read(file_io, format=fmt)
+
+        lengths_and_angles = loaded_atoms.get_cell_lengths_and_angles()
+        self._unit_lengths = lengths_and_angles[:3]
+        self._unit_angles = lengths_and_angles[3:]
+
+        # ase has a make_supercell method, unfortunately this is not suitable
+        # as need indices to remain same for linking to other files
+        if (self._unit_angles != 90).any():
+            raise ValueError(
+                f"Structure file '{file_io}' has unsupported unit cell angles"
+            )
+
+        self._atoms = [None] * len(loaded_atoms)
+
+        # Store only needed data for calculations
+        for i, loaded_atom in enumerate(loaded_atoms):
+            if loaded_atom.symbol == muon_symbol:
+                self._muon_index = i
+
+            self._atoms[i] = CellAtom(i, loaded_atom.symbol, loaded_atom.position)
+
+        if self._muon_index is None:
+            raise ValueError(
+                f"Structure file '{file_io}' has no muon with symbol " f"{muon_symbol}"
+            )
+
+    def expand(self, offsets: List[ArrayLike]):
+        """Expands the structure by duplicating loaded atoms (ignoring the
+           muon)
+
+        Expands the structure by cloning atoms (excluding the muon) given
+        offsets to to modify their positions by.
+
+        Arguments:
+            offsets {List[ArrayLike]} -- Offset for the new atoms that will be
+                                         added. For each offset will duplicate
+                                         the current structure.
+        """
+
+        new_atoms = []
+        for offset in offsets:
+            # Copy everything but the muon
+            for i, atom in enumerate(self._atoms):
+                if i != self._muon_index:
+                    new_atoms.append(
+                        CellAtom(
+                            index=atom.index,
+                            symbol=atom.symbol,
+                            position=atom.position + offset,
+                        )
+                    )
+        self._atoms.extend(new_atoms)
+
+    def layer_expand(self, layers: int):
+        """Expands the structure outwards by duplicating it.
+
+        Expands the structure outwards by duplicating it a specified number of
+        layers.
+
+        Arguments:
+            layers {int} -- Number of layers to append e.g. if layers = 1,
+                            will expand along the x, y and z axes creating a
+                            structure 9 times larger than the original.
+        """
+
+        # Construct the offsets
+        x_values = np.arange(
+            -layers * self._unit_lengths[0],
+            (layers + 1) * self._unit_lengths[0],
+            self._unit_lengths[0],
+        )
+        y_values = np.arange(
+            -layers * self._unit_lengths[1],
+            (layers + 1) * self._unit_lengths[1],
+            self._unit_lengths[1],
+        )
+        z_values = np.arange(
+            -layers * self._unit_lengths[2],
+            (layers + 1) * self._unit_lengths[2],
+            self._unit_lengths[2],
+        )
+        offsets = np.array(np.meshgrid(x_values, y_values, z_values)).T.reshape(-1, 3)
+        # Remove 0, 0, 0
+        offsets = np.delete(offsets, int(np.floor(len(offsets) / 2)), axis=0)
+
+        # Now expand for each
+        self.expand(offsets)
+
+    def compute_distances(self):
+        """Computes the vectors and distances between the muon and every atom.
+
+        Computes the vectors and distances between the muon and every atom.
+        """
+        muon = self._atoms[self._muon_index]
+
+        for atom in self._atoms:
+            atom.vector_from_muon = muon.position - atom.position
+            atom.distance_from_muon = np.linalg.norm(atom.vector_from_muon)
+
+    def get_closer_than(
+        self, distance: float, ignored_symbols: Optional[List[str]] = None
+    ) -> List[CellAtom]:
+        """Returns atoms which are closer to the muon than a given distance
+
+        Expects compute_distances to have been called first.
+
+        Arguments:
+            distance {float} -- Distance that the returned atoms should be
+                                closer than.
+            ignored_symbols {List[str]} -- List of symbols to ignore. May be
+                                           None.
+
+        Returns:
+            List[CellAtom] -- List of atoms closer than the given distance
+        """
+
+        if ignored_symbols is None:
+            return filter(
+                lambda atom: atom.distance_from_muon < distance
+                and atom.distance_from_muon != 0.0,
+                self._atoms,
+            )
+        else:
+            return filter(
+                lambda atom: atom.distance_from_muon < distance
+                and atom.distance_from_muon != 0.0
+                and atom.symbol not in ignored_symbols,
+                self._atoms,
+            )
+
+    def get_closest(
+        self, number: int, ignored_symbols: Optional[List[str]] = None
+    ) -> List[CellAtom]:
+        """Returns atoms the closest 'number' atoms to the muon.
+
+        Expects compute_distances to have been called first.
+
+        Arguments:
+            number {int} -- Number of closest atoms to return. If number > the
+                            number of atoms will only return what was
+                            available.
+            ignored_symbols {List[str]} -- List of symbols to ignore. May be
+                                           None.
+
+        Returns:
+            List[CellAtom] -- List of the found closest atoms to the muon
+                              (ignoring any in ignored_symbols)
+        """
+
+        number = min(number, len(self._atoms))
+
+        ordered_atoms = sorted(self._atoms, key=lambda atom: atom.distance_from_muon)
+
+        # Remove any that should be ignored
+        if ignored_symbols is not None:
+            ordered_atoms = filter(
+                lambda atom: atom.symbol not in ignored_symbols, ordered_atoms
+            )
+
+        # Return closest 'number' atoms (ignoring the muon itself)
+        return sorted(ordered_atoms, key=lambda atom: atom.distance_from_muon)[
+            1 : (number + 1)
+        ]

--- a/muspinsim/tests/test_generator.py
+++ b/muspinsim/tests/test_generator.py
@@ -57,7 +57,6 @@ class TestGenerator(unittest.TestCase):
                 QuadrupoleIntGenerator(GIPAWOutput(StringIO(TEST_GIPAW_FILE_DATA))),
             ],
             number_closest=4,
-            muon_symbol="H",
             additional_ignored_symbols=[],
         )
 
@@ -161,7 +160,6 @@ quadrupolar 5
                 ),
             ],
             number_closest=4,
-            muon_symbol="H",
             additional_ignored_symbols=[],
         )
 
@@ -182,13 +180,12 @@ quadrupolar 5
                 "--dipolar",
             ]
         )
-        mock_MuonatedStructure.assert_called_with("V3Si_SC.cell")
+        mock_MuonatedStructure.assert_called_with("V3Si_SC.cell", muon_symbol="H")
         mock_generate_input_file.assert_called_with(
             GeneratorToolParams(
                 structure=mock_MuonatedStructure.return_value,
                 generators=[ANY],
                 number_closest=4,
-                muon_symbol="H",
                 additional_ignored_symbols=[],
                 max_layer=6,
             )
@@ -217,14 +214,13 @@ quadrupolar 5
                 "Cu",
             ]
         )
-        mock_MuonatedStructure.assert_called_with("V3Si_SC.cell")
+        mock_MuonatedStructure.assert_called_with("V3Si_SC.cell", muon_symbol="Cu")
         mock_GIPAWOutput.assert_called_with("./efg_nospin.out")
         mock_generate_input_file.assert_called_with(
             GeneratorToolParams(
                 structure=mock_MuonatedStructure.return_value,
                 generators=[ANY, ANY],
                 number_closest=6,
-                muon_symbol="Cu",
                 additional_ignored_symbols=["Si", "F"],
                 max_layer=3,
             )

--- a/muspinsim/tests/test_generator.py
+++ b/muspinsim/tests/test_generator.py
@@ -1,0 +1,167 @@
+from io import StringIO
+import unittest
+
+from muspinsim.input.gipaw import GIPAWOutput
+from muspinsim.input.structure import MuonatedStructure
+from muspinsim.tools.generator import (
+    DipoleIntGenerator,
+    GeneratorToolParams,
+    QuadrupoleIntGenerator,
+    generate_input_file,
+)
+
+TEST_CELL_FILE_DATA = """%BLOCK LATTICE_CART
+   14.18160000000000   0.000000000000000   0.000000000000000
+   0.000000000000000   14.18160000000000   0.000000000000000
+   0.000000000000000   0.000000000000000   14.18160000000000
+%ENDBLOCK LATTICE_CART
+
+%BLOCK POSITIONS_FRAC
+V             0.0791557133        0.0000005853        0.1708904764
+V             0.9161667724        0.0000005823        0.8325662729
+Si            0.4996287249        0.8331358706        0.8331663251
+H             0.1666672745        0.0000018274        0.0833332099
+%ENDBLOCK POSITIONS_FRAC
+"""
+
+TEST_GIPAW_FILE_DATA = """     ----- total EFG -----
+     V    1       -0.008877        0.000022       -0.011811
+     V    1        0.000022       -0.030585        0.000005
+     V    1       -0.011811        0.000005        0.039462
+
+     V    2        0.221597       -0.000002       -0.009013
+     V    2       -0.000002       -0.109627       -0.000009
+     V    2       -0.009013       -0.000009       -0.111970
+
+     Si   3       -0.002604       -0.000000       -0.000001
+     Si   3       -0.000000       -0.002551       -0.000009
+     Si   3       -0.000001       -0.000009        0.005154
+
+     H    4       -0.034266        0.000000        0.000000
+     H    4        0.000000       -0.034268        0.000000
+     H    4        0.000000        0.000000        0.068534
+"""
+
+
+class TestGenerator(unittest.TestCase):
+    def test_generate_input_file(self):
+        # No ignored symbols
+        generate_params = GeneratorToolParams(
+            structure=MuonatedStructure(
+                StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell"
+            ),
+            generators=[
+                DipoleIntGenerator(),
+                QuadrupoleIntGenerator(GIPAWOutput(StringIO(TEST_GIPAW_FILE_DATA))),
+            ],
+            number_closest=4,
+            muon_symbol="H",
+            additional_ignored_symbols=[],
+        )
+
+        input_file_text = generate_input_file(generate_params)
+        self.assertEqual(
+            input_file_text,
+            """spins
+    mu V V Si Si
+dipolar 1 2
+    1.2410539563139198 1.7614965359999998e-05 -1.2417021305964
+quadrupolar 2
+    -0.008877 2.2e-05 -0.011811
+    2.2e-05 -0.030585 5e-06
+    -0.011811 5e-06 0.039462
+dipolar 1 3
+    3.5524979205813603 1.7657510159999996e-05 3.5562763937592
+quadrupolar 3
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
+dipolar 1 4
+    -4.72192610499264 2.366426252954879 3.54776669347968
+quadrupolar 4
+    -0.002604 -0.0 -1e-06
+    -0.0 -0.002551 -9e-06
+    -1e-06 -9e-06 0.005154
+dipolar 1 5
+    9.45967389500736 2.366426252954879 3.54776669347968
+quadrupolar 5
+    -0.002604 -0.0 -1e-06
+    -0.0 -0.002551 -9e-06
+    -1e-06 -9e-06 0.005154
+""",
+        )
+
+        # Ignore Si
+        generate_params.additional_ignored_symbols = ["Si"]
+
+        input_file_text = generate_input_file(generate_params)
+        self.assertEqual(
+            input_file_text,
+            """spins
+    mu V V V V
+dipolar 1 2
+    1.2410539563139198 1.7614965359999998e-05 -1.2417021305964
+quadrupolar 2
+    -0.008877 2.2e-05 -0.011811
+    2.2e-05 -0.030585 5e-06
+    -0.011811 5e-06 0.039462
+dipolar 1 3
+    3.5524979205813603 1.7657510159999996e-05 3.5562763937592
+quadrupolar 3
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
+dipolar 1 4
+    3.5524979205813603 1.7657510159999996e-05 -10.6253236062408
+quadrupolar 4
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
+dipolar 1 5
+    -10.62910207941864 1.7657510159999996e-05 3.5562763937592
+quadrupolar 5
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
+""",
+        )
+
+    def test_generate_input_error(self):
+        # Should fail as indices in GIPAW file wont align
+        generate_params = GeneratorToolParams(
+            structure=MuonatedStructure(
+                StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell"
+            ),
+            generators=[
+                DipoleIntGenerator(),
+                QuadrupoleIntGenerator(
+                    GIPAWOutput(
+                        StringIO(
+                            """     ----- total EFG -----
+     V    1       -0.008877        0.000022       -0.011811
+     V    1        0.000022       -0.030585        0.000005
+     V    1       -0.011811        0.000005        0.039462
+
+     V    2        0.221597       -0.000002       -0.009013
+     V    2       -0.000002       -0.109627       -0.000009
+     V    2       -0.009013       -0.000009       -0.111970
+
+     Si 168       -0.002604       -0.000000       -0.000001
+     Si 168       -0.000000       -0.002551       -0.000009
+     Si 168       -0.000001       -0.000009        0.005154
+
+     H  217       -0.034266        0.000000        0.000000
+     H  217        0.000000       -0.034268        0.000000
+     H  217        0.000000        0.000000        0.068534
+"""
+                        )
+                    )
+                ),
+            ],
+            number_closest=4,
+            muon_symbol="H",
+            additional_ignored_symbols=[],
+        )
+
+        with self.assertRaises(ValueError):
+            generate_input_file(generate_params)

--- a/muspinsim/tests/test_gipaw.py
+++ b/muspinsim/tests/test_gipaw.py
@@ -4,7 +4,9 @@ import numpy as np
 
 from muspinsim.input.gipaw import GIPAWAtom, GIPAWOutput
 
-TEST_GIPAW_FILE_DATA = """     ----- total EFG -----
+TEST_GIPAW_FILE_DATA = """     H  217        0.000008       -0.000024        0.068534
+
+     ----- total EFG -----
      V    1       -0.008877        0.000022       -0.011811
      V    1        0.000022       -0.030585        0.000005
      V    1       -0.011811        0.000005        0.039462
@@ -20,6 +22,9 @@ TEST_GIPAW_FILE_DATA = """     ----- total EFG -----
      H  217       -0.034266        0.000000        0.000000
      H  217        0.000000       -0.034268        0.000000
      H  217        0.000000        0.000000        0.068534
+
+
+     NQR/NMR SPECTROSCOPIC PARAMETERS:
 """
 
 

--- a/muspinsim/tests/test_gipaw.py
+++ b/muspinsim/tests/test_gipaw.py
@@ -1,0 +1,112 @@
+from io import StringIO
+import unittest
+import numpy as np
+
+from muspinsim.input.gipaw import GIPAWAtom, GIPAWOutput
+
+TEST_GIPAW_FILE_DATA = """     ----- total EFG -----
+     V    1       -0.008877        0.000022       -0.011811
+     V    1        0.000022       -0.030585        0.000005
+     V    1       -0.011811        0.000005        0.039462
+
+     V    2        0.221597       -0.000002       -0.009013
+     V    2       -0.000002       -0.109627       -0.000009
+     V    2       -0.009013       -0.000009       -0.111970
+
+     Si 168       -0.002604       -0.000000       -0.000001
+     Si 168       -0.000000       -0.002551       -0.000009
+     Si 168       -0.000001       -0.000009        0.005154
+
+     H  217       -0.034266        0.000000        0.000000
+     H  217        0.000000       -0.034268        0.000000
+     H  217        0.000000        0.000000        0.068534
+"""
+
+
+class GIPAWAtomMatcher:
+    expected: GIPAWAtom
+
+    def __init__(self, expected):
+        self.expected = expected
+
+    def __repr__(self):
+        return repr(self.expected)
+
+    def __eq__(self, other):
+        return self.expected.index == other.index and np.allclose(
+            self.expected.efg_tensor, other.efg_tensor
+        )
+
+
+class TestGIPAW(unittest.TestCase):
+    def test_parsing(self):
+        gipaw_out_file = GIPAWOutput(StringIO(TEST_GIPAW_FILE_DATA))
+
+        self.assertEqual(len(gipaw_out_file._atoms), 4)
+        self.assertEqual(
+            GIPAWAtomMatcher(gipaw_out_file._atoms[2]),
+            GIPAWAtom(
+                index=168,
+                efg_tensor=np.array(
+                    [
+                        [-2.604e-03, -0.000e00, -1.000e-06],
+                        [-0.000e00, -2.551e-03, -9.000e-06],
+                        [-1.000e-06, -9.000e-06, 5.154e-03],
+                    ]
+                ),
+            ),
+        )
+
+    def test_parsing_errors(self):
+        with self.assertRaises(ValueError):
+            GIPAWOutput(
+                StringIO(
+                    """     ----- total EFG -----
+     V    1       -0.008877        0.000022       -0.011811
+     V    2        0.000022       -0.030585        0.000005
+     V    1       -0.011811        0.000005        0.039462"""
+                )
+            )
+
+        with self.assertRaises(ValueError):
+            GIPAWOutput(
+                StringIO(
+                    """     ----- total EFG -----
+     V    1       -0.008877        0.000022       -0.011811
+     Si   1        0.000022       -0.030585        0.000005
+     V    1       -0.011811        0.000005        0.039462"""
+                )
+            )
+
+    def test_find_atom(self):
+        gipaw_out_file = GIPAWOutput(StringIO(TEST_GIPAW_FILE_DATA))
+
+        # Atom that will be at the corresponding index
+        self.assertEqual(
+            GIPAWAtomMatcher(gipaw_out_file.find_atom(2)),
+            GIPAWAtom(
+                index=2,
+                efg_tensor=np.array(
+                    [
+                        [2.21597e-01, -2.00000e-06, -9.01300e-03],
+                        [-2.00000e-06, -1.09627e-01, -9.00000e-06],
+                        [-9.01300e-03, -9.00000e-06, -1.11970e-01],
+                    ]
+                ),
+            ),
+        )
+
+        # This will not be at the corresponding index
+        self.assertEqual(
+            GIPAWAtomMatcher(gipaw_out_file.find_atom(168)),
+            GIPAWAtom(
+                index=168,
+                efg_tensor=np.array(
+                    [
+                        [-2.604e-03, -0.000e00, -1.000e-06],
+                        [-0.000e00, -2.551e-03, -9.000e-06],
+                        [-1.000e-06, -9.000e-06, 5.154e-03],
+                    ]
+                ),
+            ),
+        )

--- a/muspinsim/tests/test_structure.py
+++ b/muspinsim/tests/test_structure.py
@@ -148,8 +148,61 @@ H             0.1666672745        0.0000018274        0.0833332099
             )
         )
 
+        # Check correct number for larger system
         offsets = structure._compute_layer_offsets(2)
         self.assertEqual(len(offsets), 98)
+
+        # Check offsets are correct for a system with different cell lengths
+        structure = MuonatedStructure(
+            StringIO(
+                """%BLOCK LATTICE_CART
+   14.18160000000000   0.000000000000000   0.000000000000000
+   0.000000000000000   20.00000000000000   0.000000000000000
+   0.000000000000000   0.000000000000000   8.000000000000000
+%ENDBLOCK LATTICE_CART
+
+%BLOCK POSITIONS_FRAC
+H             0.1666672745        0.0000018274        0.0833332099
+%ENDBLOCK POSITIONS_FRAC"""
+            ),
+            fmt="castep-cell",
+        )
+        offsets = structure._compute_layer_offsets(1)
+        self.assertTrue(
+            np.allclose(
+                offsets,
+                np.array(
+                    [
+                        [-14.1816, -20.0, -8.0],
+                        [-14.1816, -20.0, 0.0],
+                        [-14.1816, -20.0, 8.0],
+                        [-14.1816, 0.0, -8.0],
+                        [-14.1816, 0.0, 0.0],
+                        [-14.1816, 0.0, 8.0],
+                        [-14.1816, 20.0, -8.0],
+                        [-14.1816, 20.0, 0.0],
+                        [-14.1816, 20.0, 8.0],
+                        [14.1816, -20.0, -8.0],
+                        [14.1816, -20.0, 0.0],
+                        [14.1816, -20.0, 8.0],
+                        [14.1816, 0.0, -8.0],
+                        [14.1816, 0.0, 0.0],
+                        [14.1816, 0.0, 8.0],
+                        [14.1816, 20.0, -8.0],
+                        [14.1816, 20.0, 0.0],
+                        [14.1816, 20.0, 8.0],
+                        [0.0, -20.0, -8.0],
+                        [0.0, -20.0, 0.0],
+                        [0.0, -20.0, 8.0],
+                        [0.0, 20.0, -8.0],
+                        [0.0, 20.0, 0.0],
+                        [0.0, 20.0, 8.0],
+                        [0.0, 0.0, -8.0],
+                        [0.0, 0.0, 8.0],
+                    ]
+                ),
+            )
+        )
 
     def test_compute_layer(self):
         structure = MuonatedStructure(StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell")

--- a/muspinsim/tests/test_structure.py
+++ b/muspinsim/tests/test_structure.py
@@ -225,8 +225,6 @@ H             0.1666672745        0.0000018274        0.0833332099
         structure = MuonatedStructure(StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell")
         new_atoms = structure.compute_layer(1, ignored_symbols=["Si"])
 
-        print(new_atoms[11])
-
         self.assertEqual(len(new_atoms), 2 * 26)  # Copy everything but muon and silicon
         self.assertEqual(
             CellAtomMatcher(new_atoms[11]),

--- a/muspinsim/tests/test_structure.py
+++ b/muspinsim/tests/test_structure.py
@@ -1,0 +1,134 @@
+from io import StringIO
+import unittest
+import numpy as np
+
+from muspinsim.input.structure import CellAtom, MuonatedStructure
+
+TEST_CELL_FILE_DATA = """%BLOCK LATTICE_CART
+   14.18160000000000   0.000000000000000   0.000000000000000
+   0.000000000000000   14.18160000000000   0.000000000000000
+   0.000000000000000   0.000000000000000   14.18160000000000
+%ENDBLOCK LATTICE_CART
+
+%BLOCK POSITIONS_FRAC
+V             0.0791557133        0.0000005853        0.1708904764
+V             0.9161667724        0.0000005823        0.8325662729
+Si            0.4996287249        0.8331358706        0.8331663251
+H             0.1666672745        0.0000018274        0.0833332099
+%ENDBLOCK POSITIONS_FRAC
+"""
+
+
+def _optional_array_close(value1, value2):
+    # Compares two values that may be an array or none
+    if value1 is None or value2 is None:
+        return value1 == value2
+    else:
+        return np.allclose(value1, value2)
+
+
+class CellAtomMatcher:
+    expected: CellAtom
+
+    def __init__(self, expected):
+        self.expected = expected
+
+    def __repr__(self):
+        return repr(self.expected)
+
+    def __eq__(self, other):
+        return (
+            self.expected.index == other.index
+            and self.expected.symbol == other.symbol
+            and _optional_array_close(self.expected.position, other.position)
+            and _optional_array_close(
+                self.expected.vector_from_muon, other.vector_from_muon
+            )
+            and np.isclose(self.expected.distance_from_muon, other.distance_from_muon)
+        )
+
+
+class TestStructure(unittest.TestCase):
+    def test_parsing(self):
+        structure = MuonatedStructure(StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell")
+
+        self.assertEqual(len(structure._atoms), 4)
+        self.assertEqual(structure._muon_index, 3)
+        self.assertEqual(
+            CellAtomMatcher(structure._atoms[2]),
+            CellAtom(
+                index=3,
+                symbol="Si",
+                isotope=1,
+                position=np.array([7.08553473, 11.81519966, 11.81563156]),
+                vector_from_muon=None,
+                distance_from_muon=None,
+            ),
+        )
+
+    def test_invalid_vector_angels(self):
+        with self.assertRaises(ValueError):
+            MuonatedStructure(
+                StringIO(
+                    """%BLOCK LATTICE_CART
+   14.18160000000000   14.18160000000000   0.000000000000000
+   0.000000000000000   14.18160000000000   0.000000000000000
+   0.000000000000000   0.000000000000000   14.18160000000000
+%ENDBLOCK LATTICE_CART
+
+%BLOCK POSITIONS_FRAC
+H             0.1666672745        0.0000018274        0.0833332099
+%ENDBLOCK POSITIONS_FRAC"""
+                ),
+                fmt="castep-cell",
+            )
+
+    def test_no_muon_found(self):
+        with self.assertRaises(ValueError):
+            MuonatedStructure(
+                StringIO(TEST_CELL_FILE_DATA),
+                muon_symbol="Cu",
+                fmt="castep-cell",
+            )
+
+    def test_multiple_muons_found(self):
+        with self.assertRaises(ValueError):
+            MuonatedStructure(
+                StringIO(TEST_CELL_FILE_DATA),
+                muon_symbol="V",
+                fmt="castep-cell",
+            )
+
+    def test_layer_expand(self):
+        structure = MuonatedStructure(StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell")
+        structure.layer_expand(1)
+
+        self.assertEqual(len(structure._atoms), 1 + 3 * 27)  # Copy everything but muon
+        self.assertEqual(structure._muon_index, 3)
+        self.assertEqual(
+            CellAtomMatcher(structure._atoms[11]),
+            CellAtom(
+                index=2,
+                symbol="V",
+                isotope=1,
+                position=np.array([-1.1888893, 14.18160826, -2.37447814]),
+                vector_from_muon=None,
+                distance_from_muon=None,
+            ),
+        )
+
+    def test_compute_distances(self):
+        structure = MuonatedStructure(StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell")
+        structure.compute_distances()
+
+        self.assertEqual(
+            CellAtomMatcher(structure._atoms[2]),
+            CellAtom(
+                index=3,
+                symbol="Si",
+                isotope=1,
+                position=np.array([7.08553473, 11.81519966, 11.81563156]),
+                vector_from_muon=np.array([-4.7219261, -11.81517375, -10.63383331]),
+                distance_from_muon=16.58231972930012,
+            ),
+        )

--- a/muspinsim/tests/test_structure.py
+++ b/muspinsim/tests/test_structure.py
@@ -109,7 +109,49 @@ H             0.1666672745        0.0000018274        0.0833332099
                 fmt="castep-cell",
             )
 
-    def test_layer_expand(self):
+    def test_compute_layer_offsets(self):
+        structure = MuonatedStructure(StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell")
+
+        offsets = structure._compute_layer_offsets(1)
+        self.assertEqual(len(offsets), 26)
+        self.assertTrue(
+            np.allclose(
+                offsets,
+                [
+                    [-14.1816, -14.1816, -14.1816],
+                    [-14.1816, -14.1816, 0.0],
+                    [-14.1816, -14.1816, 14.1816],
+                    [-14.1816, 0.0, -14.1816],
+                    [-14.1816, 0.0, 0.0],
+                    [-14.1816, 0.0, 14.1816],
+                    [-14.1816, 14.1816, -14.1816],
+                    [-14.1816, 14.1816, 0.0],
+                    [-14.1816, 14.1816, 14.1816],
+                    [14.1816, -14.1816, -14.1816],
+                    [14.1816, -14.1816, 0.0],
+                    [14.1816, -14.1816, 14.1816],
+                    [14.1816, 0.0, -14.1816],
+                    [14.1816, 0.0, 0.0],
+                    [14.1816, 0.0, 14.1816],
+                    [14.1816, 14.1816, -14.1816],
+                    [14.1816, 14.1816, 0.0],
+                    [14.1816, 14.1816, 14.1816],
+                    [0.0, -14.1816, -14.1816],
+                    [0.0, -14.1816, 0.0],
+                    [0.0, -14.1816, 14.1816],
+                    [0.0, 14.1816, -14.1816],
+                    [0.0, 14.1816, 0.0],
+                    [0.0, 14.1816, 14.1816],
+                    [0.0, 0.0, -14.1816],
+                    [0.0, 0.0, 14.1816],
+                ],
+            )
+        )
+
+        offsets = structure._compute_layer_offsets(2)
+        self.assertEqual(len(offsets), 98)
+
+    def test_compute_layer(self):
         structure = MuonatedStructure(StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell")
         new_atoms = structure.compute_layer(1)
 
@@ -126,7 +168,7 @@ H             0.1666672745        0.0000018274        0.0833332099
             ),
         )
 
-    def test_layer_expand_ignore(self):
+    def test_compute_layer_ignore(self):
         structure = MuonatedStructure(StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell")
         new_atoms = structure.compute_layer(1, ignored_symbols=["Si"])
 
@@ -149,8 +191,7 @@ H             0.1666672745        0.0000018274        0.0833332099
         structure = MuonatedStructure(StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell")
         closest_atoms = structure.compute_closest(1)
 
-        print(closest_atoms[0])
-
+        self.assertEqual(len(closest_atoms), 1)
         self.assertEqual(
             CellAtomMatcher(closest_atoms[0]),
             CellAtom(
@@ -162,5 +203,23 @@ H             0.1666672745        0.0000018274        0.0833332099
                     [1.24105396e00, 1.76149654e-05, -1.24170213e00]
                 ),
                 distance_from_muon=1.7555737250028431,
+            ),
+        )
+
+        more_closest_atoms = structure.compute_closest(6)
+
+        self.assertEqual(len(more_closest_atoms), 6)
+        self.assertEqual(CellAtomMatcher(closest_atoms[0]), more_closest_atoms[0])
+        self.assertEqual(
+            CellAtomMatcher(more_closest_atoms[5]),
+            CellAtom(
+                index=2,
+                symbol="V",
+                isotope=1,
+                position=np.array([1.29927107e01, 8.25794568e-06, -2.37447814e00]),
+                vector_from_muon=np.array(
+                    [-1.06291021e01, 1.76575102e-05, 3.55627639e00]
+                ),
+                distance_from_muon=11.208251995910084,
             ),
         )

--- a/muspinsim/tests/test_structure.py
+++ b/muspinsim/tests/test_structure.py
@@ -274,3 +274,9 @@ H             0.1666672745        0.0000018274        0.0833332099
                 distance_from_muon=11.208251995910084,
             ),
         )
+
+    def test_compute_closest_max_layer(self):
+        structure = MuonatedStructure(StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell")
+
+        with self.assertRaises(RuntimeError):
+            structure.compute_closest(6, max_layer=1)

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -78,8 +78,6 @@ class GeneratorToolParams:
         generators {List[InteractionGenerator]} -- List of generators for
                                                 generating interaction terms
         number_closest {int} -- Number of closest atoms to the muon to include
-        layer_expand_number {int} -- Number of layers to expand to for the
-                                     supercell
         muon_symbol {str} -- Symbol for the muon in the loaded files
         additional_ignored_symbols {List[str]} -- List of additional symbols
                                     to ignore when counting the closest atoms.
@@ -91,7 +89,6 @@ class GeneratorToolParams:
     structure: MuonatedStructure
     generators: List[InteractionGenerator]
     number_closest: int
-    layer_expand_number: int = 3
     muon_symbol: str = "H"
     additional_ignored_symbols: List[str] = field(default_factory=list)
 
@@ -109,10 +106,7 @@ def generate_input_file(params: GeneratorToolParams) -> str:
     """
 
     # Locate closest elements (ignoring ones with zero spin)
-    params.structure.layer_expand(params.layer_expand_number)
-    params.structure.compute_distances()
-
-    selected_atoms = params.structure.get_closest(
+    selected_atoms = params.structure.compute_closest(
         params.number_closest,
         params.structure.symbols_zero_spin + params.additional_ignored_symbols,
     )
@@ -193,15 +187,6 @@ include quadrupolar couplings.""",
         default="H",
     )
     parser.add_argument(
-        "--expand_number",
-        dest="expand_number",
-        type=int,
-        help="""Number of layers the structure should be expanded to before
-computing distances (default: 3). Larger values may be needed when searching
-for many atoms.""",
-        default=3,
-    )
-    parser.add_argument(
         "--ignore_symbol",
         dest="ignored_symbols",
         action="append",
@@ -224,7 +209,6 @@ symbol when finding the closest atoms.""",
         structure=MuonatedStructure(args.filepath),
         generators=generators,
         number_closest=args.number_closest,
-        layer_expand_number=args.expand_number,
         muon_symbol=args.muon_symbol,
         additional_ignored_symbols=args.ignored_symbols,
     )

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+import argparse
+from dataclasses import dataclass, field
 from typing import List
 
 from muspinsim.input.structure import CellAtom, MuonatedStructure
@@ -74,10 +75,17 @@ class GeneratorToolParams:
 
     Arguments:
         structure {MuonatedStructure} -- Structure to compute terms from
+        generators {List[InteractionGenerator]} -- List of generators for
+                                                generating interaction terms
+        number_closest {int} -- Number of closest atoms to the muon to include
         layer_expand_number {int} -- Number of layers to expand to for the
                                      supercell
-        number_closest {int} -- Number of closest atoms to the muon to include
         muon_symbol {str} -- Symbol for the muon in the loaded files
+        additional_ignored_symbols {List[str]} -- List of additional symbols
+                                    to ignore when counting the closest atoms.
+                                    All spin 0 isotopes will be ignored by
+                                    default but currently this data is not
+                                    reflected by soprano for Si.
     """
 
     structure: MuonatedStructure
@@ -85,6 +93,7 @@ class GeneratorToolParams:
     number_closest: int
     layer_expand_number: int = 3
     muon_symbol: str = "H"
+    additional_ignored_symbols: List[str] = field(default_factory=list)
 
 
 def generate_input_file(params: GeneratorToolParams) -> str:
@@ -103,7 +112,8 @@ def generate_input_file(params: GeneratorToolParams) -> str:
     params.structure.compute_distances()
 
     selected_atoms = params.structure.get_closest(
-        params.number_closest, params.structure.symbols_zero_spin
+        params.number_closest,
+        params.structure.symbols_zero_spin + params.additional_ignored_symbols,
     )
 
     # Generate input file
@@ -137,3 +147,91 @@ def generate_input_file(params: GeneratorToolParams) -> str:
 {input_file}"""
 
     return input_file
+
+
+def main():
+    """Entrypoint for command line tool"""
+
+    parser = argparse.ArgumentParser(
+        description="""Generate a MuSpinSim input file using a structure file
+(.cell or .cif).""",
+    )
+
+    # Required arguments
+    parser.add_argument("filepath", type=str, help="Structure file filepath")
+    parser.add_argument(
+        "number_closest",
+        type=int,
+        help="Number of nearest atoms to the muon stopping site to include",
+    )
+    # Optional arguments
+    parser.add_argument(
+        "--dipolar",
+        dest="dipolar",
+        action="store_true",
+        help="Specify to include dipolar couplings.",
+    )
+    parser.add_argument(
+        "--quadrupolar",
+        dest="gipaw_filepath",
+        type=str,
+        help="""Filepath for GIPAW output data defining the EFGs to be used to
+include quadrupolar couplings.""",
+    )
+    parser.add_argument(
+        "--out",
+        dest="output",
+        type=str,
+        help="Filepath for the output file to generate",
+    )
+    parser.add_argument(
+        "--muon_symbol",
+        dest="muon_symbol",
+        type=str,
+        help="Symbol used to identify the muon (default: H)",
+        default="H",
+    )
+    parser.add_argument(
+        "--expand_number",
+        dest="expand_number",
+        type=int,
+        help="""Number of layers the structure should be expanded to before
+computing distances (default: 3). Larger values may be needed when searching
+for many atoms.""",
+        default=3,
+    )
+    parser.add_argument(
+        "--ignore_symbol",
+        dest="ignored_symbols",
+        action="append",
+        help="""Allows certain elements in the cell file to be ignored by their
+symbol when finding the closest atoms.""",
+        default=[],
+    )
+
+    args = parser.parse_args()
+
+    # Terms to generate
+    generators = []
+
+    if args.dipolar:
+        generators.append(DipoleIntGenerator())
+    if args.gipaw_filepath is not None:
+        generators.append(QuadrupoleIntGenerator(GIPAWOutput(args.gipaw_filepath)))
+
+    generate_params = GeneratorToolParams(
+        structure=MuonatedStructure(args.filepath),
+        generators=generators,
+        number_closest=args.number_closest,
+        layer_expand_number=args.expand_number,
+        muon_symbol=args.muon_symbol,
+        additional_ignored_symbols=args.ignored_symbols,
+    )
+
+    file_data = generate_input_file(generate_params)
+
+    if args.output is not None:
+        with open(args.output, "w", encoding="utf-8") as file:
+            file.write(file_data)
+    else:
+        print(file_data)

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -98,11 +98,13 @@ def generate_input_file(params: GeneratorToolParams) -> str:
         params {GeneratorToolParams} -- Parameters (see above for details)
     """
 
-    # Locate closest elements
+    # Locate closest elements (ignoring ones with zero spin)
     params.structure.layer_expand(params.layer_expand_number)
     params.structure.compute_distances()
 
-    selected_atoms = params.structure.get_closest(params.number_closest)
+    selected_atoms = params.structure.get_closest(
+        params.number_closest, params.structure.symbols_zero_spin
+    )
 
     # Generate input file
     selected_symbols = "mu"

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -1,0 +1,132 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List
+
+from muspinsim.input.structure import CellAtom, MuonatedStructure
+from muspinsim.input.gipaw import GIPAWOutput
+
+
+class InteractionGenerator(ABC):
+    """
+    Abstract base class for handling the generation of muspinsim interaction
+    config
+    """
+
+    @abstractmethod
+    def gen_config(
+        self, muon_file_index: int, atom_file_index: int, atom: CellAtom
+    ) -> str:
+        """Should return the config required for a given atom using this
+        generator
+
+        Arguments:
+            muon_file_index {int} -- Index of the muon in the file (starts
+                                     from 1)
+            atom_file_index {int} -- Index of the muon in the file (starts
+                                     from 1)
+            atom {CellAtom} -- Atom to generate config for
+        """
+
+
+class DipoleIntGenerator(InteractionGenerator):
+    """
+    Generator for the dipole interaction
+    """
+
+    def gen_config(
+        self, muon_file_index: int, atom_file_index: int, atom: CellAtom
+    ) -> str:
+        return f"""dipolar {muon_file_index} {atom_file_index}
+    {" ".join(map(str, atom.vector_from_muon))}"""
+
+
+class QuadrupoleIntGenerator(InteractionGenerator):
+    """
+    Generator for the dipole interaction
+    """
+
+    _gipaw_file: GIPAWOutput
+
+    def __init__(self, gipaw_file: GIPAWOutput):
+        self._gipaw_file = gipaw_file
+
+    def gen_config(
+        self, muon_file_index: int, atom_file_index: int, atom: CellAtom
+    ) -> str:
+        # Obtain corresponding EFG tensor
+        gipaw_atom = self._gipaw_file.find_atom(atom.index)
+
+        if gipaw_atom is None:
+            raise ValueError(
+                f"Unable to locate atom with index {atom.index} in GIPAW output file"
+            )
+        efg_tensor = gipaw_atom.efg_tensor
+
+        return f"""quadrupolar {atom_file_index}
+    {' '.join(map(str, efg_tensor[0]))}
+    {' '.join(map(str, efg_tensor[1]))}
+    {' '.join(map(str, efg_tensor[2]))}"""
+
+
+@dataclass
+class GeneratorToolParams:
+    """Structure for storing parameters for the interaction generator tool
+
+    Arguments:
+        structure {MuonatedStructure} -- Structure to compute terms from
+        layer_expand_number {int} -- Number of layers to expand to for the
+                                     supercell
+        number_closest {int} -- Number of closest atoms to the muon to include
+        muon_symbol {str} -- Symbol for the muon in the loaded files
+    """
+
+    structure: MuonatedStructure
+    generators: List[InteractionGenerator]
+    number_closest: int
+    layer_expand_number: int = 3
+    muon_symbol: str = "H"
+
+
+def generate_input_file(params: GeneratorToolParams) -> str:
+    """Utility function for generating muspinsim input config given a
+    structure as input
+
+    Will expand the muonated structure but the amount requested and
+    locate
+
+    Arguments:
+        params {GeneratorToolParams} -- Parameters (see above for details)
+    """
+
+    # Locate closest elements
+    params.structure.layer_expand(params.layer_expand_number)
+    params.structure.compute_distances()
+
+    selected_atoms = params.structure.get_closest(params.number_closest)
+
+    # Generate input file
+    selected_symbols = "mu"
+    muon_file_index = 1
+    atom_file_index = 2
+
+    input_file = ""
+
+    for selected_atom in selected_atoms:
+        selected_symbols += f" {selected_atom.symbol}"
+
+        for generator in params.generators:
+            input_file += f"""{
+                generator.gen_config(
+                    muon_file_index,
+                    atom_file_index,
+                    selected_atom
+                )
+            }\n"""
+
+        atom_file_index += 1
+
+    input_file = f"""spins
+    {selected_symbols}
+{input_file}"""
+
+    return input_file

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -17,13 +17,13 @@ class InteractionGenerator(ABC):
     def gen_config(
         self, muon_file_index: int, atom_file_index: int, atom: CellAtom
     ) -> str:
-        """Should return the config required for a given atom using this
-        generator
+        """Should return the config required for an interaction between the muon
+        and given atom using this generator
 
         Arguments:
             muon_file_index {int} -- Index of the muon in the file (starts
                                      from 1)
-            atom_file_index {int} -- Index of the muon in the file (starts
+            atom_file_index {int} -- Index of the atom in the file (starts
                                      from 1)
             atom {CellAtom} -- Atom to generate config for
         """
@@ -43,7 +43,7 @@ class DipoleIntGenerator(InteractionGenerator):
 
 class QuadrupoleIntGenerator(InteractionGenerator):
     """
-    Generator for the dipole interaction
+    Generator for the quadrupole interaction
     """
 
     _gipaw_file: GIPAWOutput
@@ -100,8 +100,9 @@ def generate_input_file(params: GeneratorToolParams) -> str:
     """Utility function for generating muspinsim input config given a
     structure as input
 
-    Will expand the muonated structure but the amount requested and
-    locate
+    Will expand the muonated structure by the amount requested and
+    locate the nearest neighbours in order to generate their interactions
+    for the config file.
 
     Arguments:
         params {GeneratorToolParams} -- Parameters (see above for details)

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -80,7 +80,6 @@ class GeneratorToolParams:
         generators {List[InteractionGenerator]} -- List of generators for
                                                 generating interaction terms
         number_closest {int} -- Number of closest atoms to the muon to include
-        muon_symbol {str} -- Symbol for the muon in the loaded files
         additional_ignored_symbols {List[str]} -- List of additional symbols
                                     to ignore when counting the closest atoms.
                                     All spin 0 isotopes will be ignored by
@@ -93,7 +92,6 @@ class GeneratorToolParams:
     structure: MuonatedStructure
     generators: List[InteractionGenerator]
     number_closest: int
-    muon_symbol: str = "H"
     additional_ignored_symbols: List[str] = field(default_factory=list)
     max_layer: int = 6
 
@@ -227,10 +225,9 @@ searching for many atoms.""",
         generators.append(QuadrupoleIntGenerator(GIPAWOutput(args.gipaw_filepath)))
 
     generate_params = GeneratorToolParams(
-        structure=MuonatedStructure(args.filepath),
+        structure=MuonatedStructure(args.filepath, muon_symbol=args.muon_symbol),
         generators=generators,
         number_closest=args.number_closest,
-        muon_symbol=args.muon_symbol,
         additional_ignored_symbols=args.ignored_symbols,
         max_layer=args.max_layer,
     )

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -112,7 +112,12 @@ def generate_input_file(params: GeneratorToolParams) -> str:
     input_file = ""
 
     for selected_atom in selected_atoms:
-        selected_symbols += f" {selected_atom.symbol}"
+        symbol = selected_atom.symbol
+
+        if selected_atom.isotope != 1:
+            symbol = f"{str(selected_atom.isotope)} {symbol}"
+
+        selected_symbols += f" {symbol}"
 
         for generator in params.generators:
             input_file += f"""{

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 import argparse
 from dataclasses import dataclass, field
 import logging
+import sys
 from typing import List
 
 from muspinsim.input.structure import CellAtom, MuonatedStructure
@@ -150,9 +151,7 @@ def generate_input_file(params: GeneratorToolParams) -> str:
     return input_file
 
 
-def main():
-    """Entrypoint for command line tool"""
-
+def _run_generator_tool(args):
     # Setup so we can see the log output
     logging.basicConfig(
         format="[%(levelname)s] [%(asctime)s] %(message)s",
@@ -217,7 +216,7 @@ searching for many atoms.""",
         default=6,
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     # Terms to generate
     generators = []
@@ -235,7 +234,6 @@ searching for many atoms.""",
         additional_ignored_symbols=args.ignored_symbols,
         max_layer=args.max_layer,
     )
-
     file_data = generate_input_file(generate_params)
 
     if args.output is not None:
@@ -243,3 +241,9 @@ searching for many atoms.""",
             file.write(file_data)
     else:
         print(file_data)
+
+
+def main():
+    """Entrypoint for command line tool"""
+
+    _run_generator_tool(sys.argv[1:])

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import argparse
 from dataclasses import dataclass, field
+import logging
 from typing import List
 
 from muspinsim.input.structure import CellAtom, MuonatedStructure
@@ -151,6 +152,13 @@ def generate_input_file(params: GeneratorToolParams) -> str:
 
 def main():
     """Entrypoint for command line tool"""
+
+    # Setup so we can see the log output
+    logging.basicConfig(
+        format="[%(levelname)s] [%(asctime)s] %(message)s",
+        level=logging.INFO,
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
     parser = argparse.ArgumentParser(
         description="""Generate a MuSpinSim input file using a structure file

--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,7 @@ def setup():
             "console_scripts": [
                 "muspinsim = muspinsim.__main__:main",
                 "muspinsim.mpi = muspinsim.__main__:main_mpi",
+                "muspinsim-gen = muspinsim.tools.generator:main",
             ]
         },
         ext_modules=ext_modules,


### PR DESCRIPTION
Adds methods to load in a structure file via `ase` (e.g. .cell) and use it to determine the closest atoms to the muon. There is then also a function to create input file text like I used for V3Si.

Still currently leaning towards keeping this out of the config file itself, due to its kind of sketchy nature as it would make it easy to make amendments to what it outputs in the case it doesn't do quite what you might expect. In this case I would think for galaxy we can use it as a library and hide the spin/interaction options when used. Then if the user wants to make modifications they can modify the resulting text file.

Current usage:
```
muspinsim-gen --help
muspinsim-gen V3Si_SC.cell 6 --dipolar --quadrupolar ./efg_nospin.out --ignore_symbol Si
```

### Notes
- ase logs warnings that castep isn't installed when loading .cell files - these can be safely ignored in most cases (it seems it does validation against the installed version when it is present)
- Looking into GIPAW it doesn't look like there is a standard output file, only the data it prints to standard out - this implementation is therefore quite sketchy and may not always work - of course we may further expand on this for other tools that may be more standardised
- Using a brute force method of finding closest atoms to the muon - there are methods in ase to compute terms in a given radius but this turned out to be extremely slow here (https://matsci.org/t/measuring-distance-with-ase/45623) - the main caveat is the user may need to be aware that the expansion may need to be increased to capture the whole structure (Currently expanding way larger than I think necessary for most cases though - so shouldn't be necessary)
- Due to the above - it may also be sketchy in the case of oddly shaped unit cells/lattice vectors - in all the files I have worked with the lattice carts all appear like
```
   R1x   0.000000000000000   0.000000000000000
   0.000000000000000   R2y   0.000000000000000
   0.000000000000000   0.000000000000000   R3y
```
- Contains some code intended to allow isotopes to be detected from the input file - this currently does nothing until we have a resolution with https://github.com/CCP-NC/soprano/issues/21 & https://github.com/lmmentel/mendeleev/issues/97