### PR TITLE
Use mendeleev for isotopes #51

### DIFF
--- a/muspinsim/constants.py
+++ b/muspinsim/constants.py
@@ -47,8 +47,8 @@ def gyromagnetic_ratio(elem="mu", iso=None):
     else:
         try:
             val = _get_isotope_data([elem], "gamma", isotope_list=[iso])[0]
-        except RuntimeError:
-            raise ValueError("Invalid isotope {0} for element {1}".format(iso, elem))
+        except RuntimeError as exc:
+            raise ValueError(f"Invalid isotope {iso} for element {elem}") from exc
 
         return val / (2e6 * np.pi)
 
@@ -71,8 +71,8 @@ def quadrupole_moment(elem="mu", iso=None):
     else:
         try:
             val = _get_isotope_data([elem], "Q", isotope_list=[iso])[0]
-        except RuntimeError:
-            raise ValueError("Invalid isotope {0} for element {1}".format(iso, elem))
+        except RuntimeError as exc:
+            raise ValueError(f"Invalid isotope {iso} for element {elem}") from exc
 
         return val
 
@@ -97,12 +97,12 @@ def spin(elem="mu", iso=None):
     elif elem == "e":
         iso = iso or 1
         if iso < 1 or int(iso) != iso:
-            raise ValueError("Invalid multiplicity {0} for electron".format(iso))
+            raise ValueError(f"Invalid multiplicity {iso} for electron")
         return 0.5 * int(iso)
     else:
         try:
             val = _get_isotope_data([elem], "I", isotope_list=[iso])[0]
-        except RuntimeError:
-            raise ValueError("Invalid isotope {0} for element {1}".format(iso, elem))
+        except RuntimeError as exc:
+            raise ValueError(f"Invalid isotope {iso} for element {elem}") from exc
 
         return val

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,7 @@ kiwisolver==1.4.2
 lark==1.1.2
 matplotlib==3.5.1
 mccabe==0.6.1
+mendeleev==0.12.1
 mypy-extensions==0.4.3
 nodeenv==1.6.0
 numpy==1.21.6; python_version <= "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ fonttools==4.33.3
 kiwisolver==1.4.2
 lark==1.1.2
 matplotlib==3.5.1
+mendeleev==0.12.1
 numpy==1.21.6; python_version <= "3.7"
 numpy==1.22.0; python_version >= "3.8" and python_version < "4.0"
 packaging==21.3

--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,7 @@ def setup():
             "numpy",
             "scipy",
             "soprano",
+            "mendeleev",
             "lark",
             "qutip",
             "pybind11",


### PR DESCRIPTION
Moves from using soprano to mendeleev as it has a much more comprehensive set of isotopes data. This fixes the issue as in #51.

Notes:

- Now including a spin Si errors with `ValueError: 0.0 is not a valid spin value` as the most abundant isotope 28Si has zero spin, whereas before it was incorrectly using 29Si with spin 1/2, using 29Si in the input will reproduce the old behaviour

Draft as still being worked on