### PR TITLE
Fix various pylint errors and warnings

### DIFF
--- a/muspinsim/celio.py
+++ b/muspinsim/celio.py
@@ -205,7 +205,7 @@ class CelioHamiltonian:
 
         return evol_op_contribs
 
-    def evolve(self, rho0, times, operators=[]):
+    def evolve(self, rho0, times, operators=None):
         """Time evolution of a state under this Hamiltonian
 
         Perform an evolution of a state described by a DensityOperator under
@@ -231,6 +231,8 @@ class CelioHamiltonian:
             ValueError -- Invalid values of times or operators
             RuntimeError -- Hamiltonian is not hermitian
         """
+        if operators is None:
+            operators = []
 
         times = np.array(times)
         if isinstance(operators, SpinOperator):
@@ -479,7 +481,7 @@ class CelioHamiltonian:
         # 0.5 and -0.5
         return results * avg_factor * 0.5
 
-    def integrate_decaying(self, rho0, tau, operators=[]):
+    def integrate_decaying(self, rho0, tau, operators=None):
         """Called to integrate one or more expectation values in time with decay
 
         Raises:

--- a/muspinsim/constants.py
+++ b/muspinsim/constants.py
@@ -47,8 +47,8 @@ def gyromagnetic_ratio(elem="mu", iso=None):
     else:
         try:
             val = _get_isotope_data([elem], "gamma", isotope_list=[iso])[0]
-        except RuntimeError:
-            raise ValueError("Invalid isotope {0} for element {1}".format(iso, elem))
+        except RuntimeError as exc:
+            raise ValueError(f"Invalid isotope {iso} for element {elem}") from exc
 
         return val / (2e6 * np.pi)
 
@@ -71,8 +71,8 @@ def quadrupole_moment(elem="mu", iso=None):
     else:
         try:
             val = _get_isotope_data([elem], "Q", isotope_list=[iso])[0]
-        except RuntimeError:
-            raise ValueError("Invalid isotope {0} for element {1}".format(iso, elem))
+        except RuntimeError as exc:
+            raise ValueError(f"Invalid isotope {iso} for element {elem}") from exc
 
         return val
 
@@ -97,12 +97,12 @@ def spin(elem="mu", iso=None):
     elif elem == "e":
         iso = iso or 1
         if iso < 1 or int(iso) != iso:
-            raise ValueError("Invalid multiplicity {0} for electron".format(iso))
+            raise ValueError(f"Invalid multiplicity {iso} for electron")
         return 0.5 * int(iso)
     else:
         try:
             val = _get_isotope_data([elem], "I", isotope_list=[iso])[0]
-        except RuntimeError:
-            raise ValueError("Invalid isotope {0} for element {1}".format(iso, elem))
+        except RuntimeError as exc:
+            raise ValueError(f"Invalid isotope {iso} for element {elem}") from exc
 
         return val

--- a/muspinsim/fitting.py
+++ b/muspinsim/fitting.py
@@ -12,7 +12,7 @@ from muspinsim.experiment import ExperimentRunner
 from muspinsim.mpi import mpi_controller as mpi
 
 
-class FittingRunner(object):
+class FittingRunner:
     def __init__(self, inpfile: MuSpinInput):
         """Initialise a FittingRunner object
 
@@ -132,23 +132,23 @@ class FittingRunner(object):
             if fname is None:
                 fname = config.name + "_fit_report.txt"
 
-            with open(os.path.join(path, fname), "w") as f:
-                f.write("Fitting process for {0} completed\n".format(config.name))
-                f.write("Success achieved: {0}\n".format(self._sol["success"]))
+            with open(os.path.join(path, fname), "w", encoding="utf-8") as file:
+                file.write("Fitting process for {0} completed\n".format(config.name))
+                file.write("Success achieved: {0}\n".format(self._sol["success"]))
                 if not self._sol["success"]:
-                    f.write("   Message: {0}\n".format(self._sol["message"]))
+                    file.write("   Message: {0}\n".format(self._sol["message"]))
 
-                f.write(
+                file.write(
                     "Final absolute error <|f-f_targ|>: "
                     "{0}\n".format(self._sol["fun"])
                 )
-                f.write("Number of simulations: {0}\n".format(self._sol["nfev"]))
-                f.write("Number of iterations: {0}\n".format(self._sol["nit"]))
+                file.write("Number of simulations: {0}\n".format(self._sol["nfev"]))
+                file.write("Number of iterations: {0}\n".format(self._sol["nit"]))
 
-                f.write("\n" + "=" * 20 + "\n")
-                f.write("\nValues found for fitting variables:\n\n")
+                file.write("\n" + "=" * 20 + "\n")
+                file.write("\nValues found for fitting variables:\n\n")
                 for name, val in variables.items():
-                    f.write("\t{0} = {1}\n".format(name, val))
+                    file.write("\t{0} = {1}\n".format(name, val))
 
     @property
     def solution(self):

--- a/muspinsim/hamiltonian.py
+++ b/muspinsim/hamiltonian.py
@@ -35,7 +35,7 @@ class Hamiltonian(Operator, Hermitian):
     def from_spin_operator(self, spinop):
         return self(spinop.matrix, spinop.dimension)
 
-    def evolve(self, rho0, times, operators=[]):
+    def evolve(self, rho0, times, operators=None):
         """Time evolution of a state under this Hamiltonian
 
         Perform an evolution of a state described by a DensityOperator under
@@ -61,6 +61,8 @@ class Hamiltonian(Operator, Hermitian):
             ValueError -- Invalid values of times or operators
             RuntimeError -- Hamiltonian is not hermitian
         """
+        if operators is None:
+            operators = []
 
         times = np.array(times)
 
@@ -113,7 +115,7 @@ class Hamiltonian(Operator, Hermitian):
                 ]
         return result
 
-    def integrate_decaying(self, rho0, tau, operators=[]):
+    def integrate_decaying(self, rho0, tau, operators=None):
         """Integrate one or more expectation values in time with decay
 
         Perform an integral in time from 0 to +inf of an expectation value
@@ -137,6 +139,8 @@ class Hamiltonian(Operator, Hermitian):
             ValueError -- Invalid values of tau or operators
             RuntimeError -- Hamiltonian is not hermitian
         """
+        if operators is None:
+            operators = []
 
         if isinstance(operators, SpinOperator):
             operators = [operators]

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -238,7 +238,7 @@ class MuSpinEvaluateKeyword(MuSpinKeyword):
         conflicts = conflicts.union(fnames.intersection(vnames))
         if len(conflicts) > 0:
             raise ValueError(
-                f"Variable names '{conflicts}' conflict with existing " "constants"
+                f"Variable names '{conflicts}' conflict with existing constants"
             )
 
         self._variables = list(cnames.union(vnames))

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -54,7 +54,7 @@ class MuSpinKeyword(object):
     expr_size_bounds = (1, np.inf)
     _validators = []
 
-    def __init__(self, block=[], args=[]):
+    def __init__(self, block=None, args=None):
         """Create an instance of a given keyword, passing the raw block of
         text as well as the arguments.
 
@@ -63,13 +63,17 @@ class MuSpinKeyword(object):
             args {[any]} -- Any arguments appearing after the keyword
 
         """
+        if block is None:
+            block = []
+        if args is None:
+            args = []
 
         # Sanity check
         if (
             self.block_size < self.block_size_bounds[0]
             or self.block_size > self.block_size_bounds[1]
         ):
-            raise RuntimeError("Invalid block_size for keyword {0}".format(self.name))
+            raise RuntimeError(f"Invalid block_size for keyword {self.name}")
 
         self._store_args(args)
 
@@ -77,15 +81,14 @@ class MuSpinKeyword(object):
         block = np.array(block)
         try:
             block = block.reshape((-1, self.block_size))
-        except ValueError:
+        except ValueError as exc:
             raise RuntimeError(
-                "Invalid number of entries for block, expected {0}, got {1}".format(
-                    self.block_size, len(block)
-                )
-            )
+                "Invalid number of entries for block, expected "
+                f"{self.block_size}, got {len(block)}"
+            ) from exc
         if not self.accept_range and len(block) > 1:
             raise RuntimeError(
-                "Can not accept range of values for keyword {0}".format(self.name)
+                f"Can not accept range of values for keyword {self.name}"
             )
 
         use_default = False
@@ -99,8 +102,8 @@ class MuSpinKeyword(object):
                 use_default = True
             else:
                 raise RuntimeError(
-                    "Input is empty and keyword '{0}' "
-                    "doesn't have a default value".format(self.name)
+                    f"Input is empty and keyword '{self.name}' "
+                    "doesn't have a default value"
                 )
 
         self._store_values(block)
@@ -111,7 +114,7 @@ class MuSpinKeyword(object):
         # expressions are within bounds (if not using defaults)
         # need to check after parsing to account for expressions and functions
         if not use_default:
-            if type(self._values) is np.ndarray:
+            if isinstance(self._values, np.ndarray):
                 entry_lengths = [
                     np.shape(self._values)[1] for _ in range(np.shape(self._values)[0])
                 ]
@@ -154,26 +157,25 @@ class MuSpinKeyword(object):
     def _store_args(self, args):
         try:
             self._args = self._default_args(*args)
-        except TypeError:
+        except TypeError as exc:
             if args:
                 raise RuntimeError(
-                    "Wrong number of in-line arguments given '{0}', "
-                    "expected {1}, got {2}".format(
-                        " ".join(args),
-                        len(inspect.signature(self._default_args).parameters),
-                        len(args),
-                    )
-                )
+                    f"""Wrong number of in-line arguments given '{
+                        ' '.join(args)
+                    }', expected {
+                        len(inspect.signature(self._default_args).parameters)
+                    }, got {len(args)}"""
+                ) from exc
             else:
                 raise RuntimeError(
-                    "This keyword requires {0} in-line arguments".format(
-                        len(inspect.signature(self._default_args).parameters),
-                    )
-                )
-        except ValueError as e:
+                    f"""This keyword requires {
+                        len(inspect.signature(self._default_args).parameters)
+                    } in-line arguments"""
+                ) from exc
+        except ValueError as exc:
             raise RuntimeError(
-                "Error parsing keyword argument(s) '{0}': {1}".format(self.name, str(e))
-            )
+                f"Error parsing keyword argument(s) '{self.name}': {str(exc)}"
+            ) from exc
 
     def _store_values(self, block):
         # Parse and store each value separately
@@ -219,7 +221,14 @@ class MuSpinEvaluateKeyword(MuSpinKeyword):
     _functions = {**_math_functions}
     _constants = {**_math_constants}
 
-    def __init__(self, block=[], args=[], variables=[]):
+    def __init__(self, block=None, args=None, variables=None):
+        # Fix W0102:dangerous-default-value
+        if block is None:
+            block = []
+        if args is None:
+            args = []
+        if variables is None:
+            variables = []
 
         cnames = set(self._constants.keys())
         fnames = set(self._functions.keys())
@@ -229,8 +238,7 @@ class MuSpinEvaluateKeyword(MuSpinKeyword):
         conflicts = conflicts.union(fnames.intersection(vnames))
         if len(conflicts) > 0:
             raise ValueError(
-                "Variable names {0}".format(conflicts)
-                + " conflict with existing constants"
+                f"Variable names '{conflicts}' conflict with existing " "constants"
             )
 
         self._variables = list(cnames.union(vnames))
@@ -292,7 +300,7 @@ class MuSpinExpandKeyword(MuSpinEvaluateKeyword):
                 eval_values += [eval_line]
             else:
                 raise RuntimeError(
-                    "Unable to evaluate expression for keyword {0}".format(self.name)
+                    f"Unable to evaluate expression for keyword {self.name}"
                 )
 
         return eval_values
@@ -321,10 +329,10 @@ class MuSpinCouplingKeyword(MuSpinEvaluateKeyword):
         i = self._args.get("i")
         j = self._args.get("j")
         if i is not None:
-            id_str += "_{0}".format(i)
+            id_str += f"_{i}"
             if j is not None:
-                id_str += "_{0}".format(j)
-        return "{0}{1}".format(self.name, id_str)
+                id_str += f"_{j}"
+        return f"{self.name}{id_str}"
 
 
 # Now on to defining the actual keywords that are admitted in input files
@@ -533,9 +541,7 @@ class KWFittingVariables(MuSpinKeyword):
     default = ""
     _constants = {**_math_constants, **_phys_constants}
     _validators = [
-        lambda s: "Invalid value '{0}': variable name conflicts with a constant".format(
-            s.name
-        )
+        lambda s: f"Invalid value '{s.name}': variable name conflicts with a constant"
         if s.name in {**_math_constants, **_phys_constants}
         else ""
     ]
@@ -583,8 +589,8 @@ class KWFittingMethod(MuSpinKeyword):
     accept_range = False
     default = "nelder-mead"
     _validators = [
-        lambda s: "Invalid value {0}, accepted values {1}".format(
-            s[0].lower(), ["nelder-mead", "lbfgs"]
+        lambda s: (
+            f"Invalid value {s[0].lower()}, accepted values ['nelder-mead', 'lbfgs']"
         )
         if s[0].lower() not in ["nelder-mead", "lbfgs"]
         else ""
@@ -598,7 +604,7 @@ class KWFittingTolerance(MuSpinKeyword):
     accept_range = False
     default = "1e-3"
     _validators = [
-        lambda s: "Invalid value '{0}', accepts only single float value".format(s[0])
+        lambda s: f"Invalid value '{s[0]}', accepts only single float value"
         if not float(s[0])
         else "",
     ]

--- a/muspinsim/input/variables.py
+++ b/muspinsim/input/variables.py
@@ -1,38 +1,35 @@
-"""variables.py
-
-Class defining a fitting variable with a starting value and bounds"""
-
 import numpy as np
 
 
-class FittingVariable(object):
-    def __init__(self, name, value=0.0, minv=-np.inf, maxv=np.inf):
+class FittingVariable:
+    """Class defining a fitting variable with a starting value and bounds"""
+
+    def __init__(self, name, value=0.0, min_value=-np.inf, max_value=np.inf):
 
         self._name = name
         self._value = float(value)
-        self._min = float(minv)
-        self._max = float(maxv)
+        self._min = float(min_value)
+        self._max = float(max_value)
 
         invalid = ""
         if self._max <= self._min:
             invalid += (
-                "Variable {0} has invalid range: "
-                "(max value {1} cannot be less than or equal to min value {2}"
-                ")\n".format(name, self._max, self._min)
+                f"Variable {name} has invalid range: "
+                f"(max value {self._max} cannot be less than or equal to min "
+                f"value {self._min}"
+                ")\n"
             )
         if self._value > self._max:
             invalid += (
-                "Variable {0} has invalid starting value: "
-                "(starting value {1} cannot be greater than max value {2})".format(
-                    name, self._value, self._max
-                )
+                f"Variable {name} has invalid starting value: "
+                f"(starting value {self._value} cannot be greater than max "
+                f"value {self._max})"
             )
         if self._value < self._min:
             invalid += (
-                "Variable {0} has invalid starting value: "
-                "(starting value {1} cannot be less than min value {2})".format(
-                    name, self._value, self._min
-                )
+                f"Variable {name} has invalid starting value: "
+                f"(starting value {self._value} cannot be less than min "
+                f"value {self._min})"
             )
 
         if invalid != "":

--- a/muspinsim/lindbladian.py
+++ b/muspinsim/lindbladian.py
@@ -112,7 +112,7 @@ class Lindbladian(SuperOperator):
 
         return result
 
-    def integrate_decaying(self, rho0, tau, operators=[]):
+    def integrate_decaying(self, rho0, tau, operators=None):
         """Integrate one or more expectation values in time with decay
 
         Perform an integral in time from 0 to +inf of an expectation value
@@ -136,6 +136,8 @@ class Lindbladian(SuperOperator):
             ValueError -- Invalid values of tau or operators
             RuntimeError -- Hamiltonian is not hermitian
         """
+        if operators is None:
+            operators = []
 
         if isinstance(operators, SpinOperator):
             operators = [operators]

--- a/muspinsim/mpi.py
+++ b/muspinsim/mpi.py
@@ -75,7 +75,7 @@ class MPIController:
             try:
                 v = self.comm.bcast(v, root=0)
             except OverflowError as exc:
-                raise OverflowError(f"Overflow error on: {k}, {v}: {str(exc)}") from exc
+                raise OverflowError(f"Overflow error on: {k}, {v}") from exc
             obj.__setattr__(k, v)
 
     def broadcast_terms(self, lst):
@@ -98,9 +98,7 @@ class MPIController:
             try:
                 val = self.comm.bcast(val, root=0)
             except OverflowError as exc:
-                raise OverflowError(
-                    f"Overflow error broadcasting term {val}: {str(exc)}"
-                ) from exc
+                raise OverflowError(f"Overflow error broadcasting term {val}") from exc
             n_list.append(val)
         return n_list
 

--- a/muspinsim/mpi.py
+++ b/muspinsim/mpi.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 
 
-class MPIController(object):
+class MPIController:
     def __init__(self):
         self._MPI = None
         self._comm = None
@@ -42,7 +42,8 @@ class MPIController(object):
         return self._rank == 0
 
     def execute_on_root(self, func):
-        # A decorator making sure a function only executes on the root node
+        """A decorator making sure a function only executes on the root node"""
+
         def decfunc(*args, **kwargs):
             if not self.is_root:
                 return None
@@ -51,15 +52,15 @@ class MPIController(object):
         return decfunc
 
     def broadcast(self, var):
-        # A function to broadcast a single variable
+        """A function to broadcast a single variable"""
 
-        if not (self.comm is None):
+        if self.comm is not None:
             var = self.comm.bcast(var, root=0)
 
         return var
 
     def broadcast_object(self, obj, selected_attrs=None):
-        # A function to broadcast an object's members
+        """A function to broadcast an object's members"""
 
         if self.comm is None:
             return  # Nothing to do
@@ -74,7 +75,7 @@ class MPIController(object):
             try:
                 v = self.comm.bcast(v, root=0)
             except OverflowError as exc:
-                raise OverflowError(f"Overflow error on: {k}, {v}") from exc
+                raise OverflowError(f"Overflow error on: {k}, {v}: {str(exc)}") from exc
             obj.__setattr__(k, v)
 
     def broadcast_terms(self, lst):
@@ -97,7 +98,9 @@ class MPIController(object):
             try:
                 val = self.comm.bcast(val, root=0)
             except OverflowError as exc:
-                raise OverflowError(f"Overflow error broadcasting term {val}") from exc
+                raise OverflowError(
+                    f"Overflow error broadcasting term {val}: {str(exc)}"
+                ) from exc
             n_list.append(val)
         return n_list
 

--- a/muspinsim/spinsys.py
+++ b/muspinsim/spinsys.py
@@ -5,8 +5,8 @@ A class to hold a given spin system, defined by specific nuclei
 
 import logging
 
-import numpy as np
 from numbers import Number
+import numpy as np
 import scipy.constants as cnst
 from scipy import sparse
 from qutip import sigmax, sigmay, sigmaz
@@ -166,7 +166,7 @@ class DissipationTerm(Clonable):
 
 
 class SpinSystem(Clonable):
-    def __init__(self, spins=[], celio_k=0):
+    def __init__(self, spins=None, celio_k=0):
         """Create a SpinSystem object
 
         Create an object representing a system of particles with spins (muons,
@@ -181,6 +181,8 @@ class SpinSystem(Clonable):
                              method is to be used. When this is 0, Celio's
                              method is not used.
         """
+        if spins is None:
+            spins = []
 
         gammas = []
         Qs = []
@@ -218,7 +220,7 @@ class SpinSystem(Clonable):
             "{1}{0}".format(*s) if (type(s) == tuple) else str(s) for s in self._spins
         ]
         logging.info("Created spin system with spins:")
-        logging.info("\t\t{0}".format(" ".join(snames)))
+        logging.info("\t\t%s", " ".join(snames))
 
     @property
     def spins(self):
@@ -375,7 +377,7 @@ class SpinSystem(Clonable):
 
         B = np.array(B)
 
-        logging.info("Adding Zeeman term to spin {0}".format(i + 1))
+        logging.info("Adding Zeeman term to spin %s", i + 1)
 
         return self.add_linear_term(i, B * self.gamma(i), "Zeeman")
 
@@ -413,7 +415,7 @@ class SpinSystem(Clonable):
         )  # MHz
         D *= dij
 
-        logging.info("Adding dipolar term to spins {0}-{1}".format(i + 1, j + 1))
+        logging.info("Adding dipolar term to spins %s-%s", i + 1, j + 1)
 
         return self.add_bilinear_term(i, j, D, "Dipolar")
 
@@ -442,7 +444,7 @@ class SpinSystem(Clonable):
 
         Qtens = EFG_2_MHZ * Q / (2 * I * (2 * I - 1)) * EFG
 
-        logging.info("Adding quadrupolar term to spin {0}".format(i + 1))
+        logging.info("Adding quadrupolar term to spin %s", i + 1)
 
         return self.add_bilinear_term(i, i, Qtens, "Quadrupolar")
 
@@ -547,7 +549,7 @@ class SpinSystem(Clonable):
 
         return self._Is[i]
 
-    def operator(self, terms={}, include_only_given=False):
+    def operator(self, terms=None, include_only_given=False):
         """Return an operator for this spin system
         Return a SpinOperator for this system containing the specified terms.
         Keyword Arguments:
@@ -563,6 +565,8 @@ class SpinSystem(Clonable):
         Returns:
             SpinOperator -- The requested operator
         """
+        if terms is None:
+            terms = {}
 
         def _get_term(i):
             # Default to identity of the appropriate size if not specified
@@ -607,10 +611,10 @@ class SpinSystem(Clonable):
         # Edit the terms
         try:
             rssys._terms = [t.rotate(rotmat) for t in terms]
-        except AttributeError:
+        except AttributeError as exc:
             raise RuntimeError(
                 "Can only rotate SpinSystems containing Single or Double terms"
-            )
+            ) from exc
 
         return rssys
 
@@ -706,7 +710,7 @@ class MuonSpinSystem(SpinSystem):
                 "First index in hyperfine coupling must not refer to an electron"
             )
 
-        logging.info("Adding hyperfine term to spins {0}-{1}".format(i + 1, j + 1))
+        logging.info("Adding hyperfine term to spins %s-%s", i + 1, j + 1)
 
         return self.add_bilinear_term(i, j, A, "Hyperfine")
 

--- a/muspinsim/tests/test_input.py
+++ b/muspinsim/tests/test_input.py
@@ -407,10 +407,10 @@ notakeyword 1
             ).evaluate()
         self.assertEqual(
             str(err.exception),
-            "Found 1 Error(s) whilst trying to parse keywords: \n\n"
+            "Found 1 error(s) whilst trying to parse keywords: \n\n"
             "Error occurred when parsing keyword 'notakeyword' "
             "(block starting at line 6):\n"
-            "Invalid keyword notakeyword found in input file",
+            "Invalid keyword 'notakeyword' found in input file",
         )
 
     def test_input_fitting(self):

--- a/muspinsim/tests/test_mpi.py
+++ b/muspinsim/tests/test_mpi.py
@@ -32,11 +32,11 @@ class TestMuSpinMPI(unittest.TestCase):
         self.assertTrue(np.all(split30[2][1] == [12, 13, 14, 15, 16]))
 
     def test_broadcast(self):
-        class A(object):
+        class A:
             def __init__(self, x):
                 self.x = x
 
-        class B(object):
+        class B:
             def __init__(self, x):
                 self.a = A(x)
 

--- a/muspinsim/utils.py
+++ b/muspinsim/utils.py
@@ -10,7 +10,7 @@ from ase.quaternions import Quaternion
 from soprano.calculate.powder import ZCW
 
 
-class Clonable(object):
+class Clonable:
     """A helper class; any object inheriting
     from this will have a .clone method that copies it easily."""
 
@@ -29,8 +29,7 @@ def deepmap(func, obj):
 
     if isinstance(obj, Iterable):
         return [deepmap(func, x) for x in obj]
-    else:
-        return func(obj)
+    return func(obj)
 
 
 def zcw_gen(N, mode="sphere"):

--- a/muspinsim/validation.py
+++ b/muspinsim/validation.py
@@ -1,6 +1,7 @@
+from numbers import Number
+
 import numpy as np
 
-from numbers import Number
 from muspinsim.spinop import DensityOperator, SpinOperator
 
 


### PR DESCRIPTION
Fixes various issues given by vscode's pylint plugin e.g.

C0116:missing-function-docstring
C0209:consider-using-f-string
C0103:invalid-name
W0102:dangerous-default-value
R0205:useless-object-inheritance
C0325:superfluous-parens
R1701:consider-merging-isinstance
C0411:wrong-import-order
R1705:no-else-return
R0401:cyclic-import

Many still remain, but its an improvement and some of these above can cause unexpected behaviour if misused.

### Notes
- Ended up leaving in various str(exc)’s despite using `raise … from …` as it has the following effect (as a result also reverted the one from #43):
![image](https://user-images.githubusercontent.com/90245114/219371356-9e79858d-551c-4c83-8154-2ef07a6dde72.png)
instead of
![image](https://user-images.githubusercontent.com/90245114/219371325-c6a07e1b-6704-4eef-9800-8f73bae9b5c8.png)

