### PR TITLE
Add magres file support for obtaining EFG tensors

### DIFF
--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -55,6 +55,9 @@ class MuonatedStructure:
 
     _symbols_zero_spin: List[str]
 
+    # Parameter optionally loaded from certain files (in this case magres)
+    _efg_tensors: Optional[List[ArrayLike]]
+
     def __init__(
         self,
         file_io: Union[str, PurePath, IO],
@@ -85,6 +88,8 @@ class MuonatedStructure:
         self._muon_index = None
         self._symbols_zero_spin = []
 
+        self._efg_tensors = None
+
         # Load the atomic data from the file
         # NOTE: Calculator is loaded automatically - can't see a way to
         # disable but this will cause warnings when reading CASTEP files
@@ -101,6 +106,11 @@ class MuonatedStructure:
             raise ValueError(
                 f"Structure file '{file_io}' has unsupported unit cell angles"
             )
+
+        # Load optional data
+        if loaded_atoms.has("efg"):
+            # Load the efg tensors
+            self._efg_tensors = loaded_atoms.get_array("efg")
 
         self._cell_atoms = [None] * len(loaded_atoms)
 
@@ -352,3 +362,18 @@ class MuonatedStructure:
         List of symbols that have zero spin
         """
         return self._symbols_zero_spin
+
+    @property
+    def has_efg_tensors(self) -> bool:
+        """Returns whether we have found and loaded EFG tensors"""
+        return self._efg_tensors is not None
+
+    def get_efg_tensor(self, atom_index: int) -> ArrayLike:
+        """Returns the EFG tensor for a given atom index
+
+        Arguments:
+            index {int} -- Index of the relevant atom (starting from 1)
+        Returns:
+            efg_tensor {ArrayLike}: EFG tensor for the atom at the given index
+        """
+        return self._efg_tensors[atom_index - 1]

--- a/muspinsim/tests/test_generator.py
+++ b/muspinsim/tests/test_generator.py
@@ -8,6 +8,7 @@ from muspinsim.tools.generator import (
     DipoleIntGenerator,
     GeneratorToolParams,
     QuadrupoleIntGenerator,
+    QuadrupoleIntGeneratorGIPAWOut,
     _run_generator_tool,
     generate_input_file,
 )
@@ -44,9 +45,43 @@ TEST_GIPAW_FILE_DATA = """     ----- total EFG -----
      H    4        0.000000        0.000000        0.068534
 """
 
+TEST_MAGRES_FILE_DATA = (
+    "#$magres-abinitio-v1.0\n"
+    "[atoms]\n"
+    "units lattice Angstrom\n"
+    "lattice          14.18160000000000   0.000000000000000   0.000000000000000"
+    "                 0.000000000000000   14.18160000000000   0.000000000000000"
+    "                 0.000000000000000   0.000000000000000   14.18160000000000\n"
+    "units atom Angstrom\n"
+    "atom V       V   1"
+    "     1.1225546637        0.0000083005        2.4235003801\n"
+    "atom V       V   2"
+    "     12.992710700        0.0000082580        11.807121856\n"
+    "atom Si      Si  3"
+    "     7.0855347250        11.815199663        11.815631556\n"
+    "atom H:mu    H:mu   1"
+    "     2.3636086201        0.0000259155        1.1817982368\n"
+    "[/atoms]\n"
+    "[magres]\n"
+    "units efg au\n"
+    "efg V  1         -0.008877        0.000022       -0.011811"
+    "                  0.000022       -0.030585        0.000005"
+    "                 -0.011811        0.000005        0.039462\n"
+    "efg V  2          0.221597       -0.000002       -0.009013"
+    "                 -0.000002       -0.109627       -0.000009"
+    "                 -0.009013       -0.000009       -0.111970\n"
+    "efg Si 3         -0.002604       -0.000000       -0.000001"
+    "                 -0.000000       -0.002551       -0.000009"
+    "                 -0.000001       -0.000009        0.005154\n"
+    "efg H:mu  1      -0.034266        0.000000        0.000000"
+    "                  0.000000       -0.034268        0.000000"
+    "                  0.000000        0.000000        0.068534\n"
+    "[/magres]\n"
+)
+
 
 class TestGenerator(unittest.TestCase):
-    def test_generate_input_file(self):
+    def test_generate_input_file_cell(self):
         # No ignored symbols
         generate_params = GeneratorToolParams(
             structure=MuonatedStructure(
@@ -54,7 +89,9 @@ class TestGenerator(unittest.TestCase):
             ),
             generators=[
                 DipoleIntGenerator(),
-                QuadrupoleIntGenerator(GIPAWOutput(StringIO(TEST_GIPAW_FILE_DATA))),
+                QuadrupoleIntGeneratorGIPAWOut(
+                    GIPAWOutput(StringIO(TEST_GIPAW_FILE_DATA))
+                ),
             ],
             number_closest=4,
             additional_ignored_symbols=[],
@@ -127,6 +164,86 @@ quadrupolar 5
 """,
         )
 
+    def test_generate_input_file_magres(self):
+        # No ignored symbols
+        structure = MuonatedStructure(StringIO(TEST_MAGRES_FILE_DATA), fmt="magres")
+        generate_params = GeneratorToolParams(
+            structure=structure,
+            generators=[
+                DipoleIntGenerator(),
+                QuadrupoleIntGenerator(structure),
+            ],
+            number_closest=4,
+            additional_ignored_symbols=[],
+        )
+
+        input_file_text = generate_input_file(generate_params)
+        self.assertEqual(
+            input_file_text,
+            """spins
+    mu V V Si Si
+dipolar 1 2
+    1.2410539564 1.7615e-05 -1.2417021433000002
+quadrupolar 2
+    -0.008877 2.2e-05 -0.011811
+    2.2e-05 -0.030585 5e-06
+    -0.011811 5e-06 0.039462
+dipolar 1 3
+    3.5524979200999995 1.7657499999999998e-05 3.556276380799999
+quadrupolar 3
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
+dipolar 1 4
+    -4.7219261049 2.3664262525 3.5477666807999997
+quadrupolar 4
+    -0.002604 -0.0 -1e-06
+    -0.0 -0.002551 -9e-06
+    -1e-06 -9e-06 0.005154
+dipolar 1 5
+    9.4596738951 2.3664262525 3.5477666807999997
+quadrupolar 5
+    -0.002604 -0.0 -1e-06
+    -0.0 -0.002551 -9e-06
+    -1e-06 -9e-06 0.005154
+""",
+        )
+
+        # Ignore Si
+        generate_params.additional_ignored_symbols = ["Si"]
+
+        input_file_text = generate_input_file(generate_params)
+        self.assertEqual(
+            input_file_text,
+            """spins
+    mu V V V V
+dipolar 1 2
+    1.2410539564 1.7615e-05 -1.2417021433000002
+quadrupolar 2
+    -0.008877 2.2e-05 -0.011811
+    2.2e-05 -0.030585 5e-06
+    -0.011811 5e-06 0.039462
+dipolar 1 3
+    3.5524979200999995 1.7657499999999998e-05 3.556276380799999
+quadrupolar 3
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
+dipolar 1 4
+    3.5524979200999995 1.7657499999999998e-05 -10.6253236192
+quadrupolar 4
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
+dipolar 1 5
+    -10.6291020799 1.7657499999999998e-05 3.556276380799999
+quadrupolar 5
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
+""",
+        )
+
     def test_generate_input_error(self):
         # Should fail as indices in GIPAW file wont align
         generate_params = GeneratorToolParams(
@@ -135,7 +252,7 @@ quadrupolar 5
             ),
             generators=[
                 DipoleIntGenerator(),
-                QuadrupoleIntGenerator(
+                QuadrupoleIntGeneratorGIPAWOut(
                     GIPAWOutput(
                         StringIO(
                             """     ----- total EFG -----
@@ -194,7 +311,7 @@ quadrupolar 5
     @patch("muspinsim.tools.generator.GIPAWOutput")
     @patch("muspinsim.tools.generator.MuonatedStructure")
     @patch("muspinsim.tools.generator.generate_input_file")
-    def test_generate_tool(
+    def test_generate_tool_gipaw(
         self, mock_generate_input_file, mock_MuonatedStructure, mock_GIPAWOutput
     ):
         _run_generator_tool(
@@ -223,5 +340,55 @@ quadrupolar 5
                 number_closest=6,
                 additional_ignored_symbols=["Si", "F"],
                 max_layer=3,
+            )
+        )
+
+    @patch("muspinsim.tools.generator.GIPAWOutput")
+    @patch("muspinsim.tools.generator.MuonatedStructure")
+    @patch("muspinsim.tools.generator.generate_input_file")
+    def test_generate_tool_invalid_quadrupolar(
+        self, mock_generate_input_file, mock_MuonatedStructure, mock_GIPAWOutput
+    ):
+        # Don't supply a GIPAW file path while not using a magres file with
+        # EFG tensors
+        structure = MuonatedStructure(StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell")
+        mock_MuonatedStructure.return_value = structure
+        with self.assertRaises(ValueError):
+            _run_generator_tool(
+                [
+                    "V3Si_SC.cell",
+                    "6",
+                    "--dipolar",
+                    "--quadrupolar",
+                ]
+            )
+        mock_MuonatedStructure.assert_called_with("V3Si_SC.cell", muon_symbol="H")
+
+    @patch("muspinsim.tools.generator.GIPAWOutput")
+    @patch("muspinsim.tools.generator.MuonatedStructure")
+    @patch("muspinsim.tools.generator.generate_input_file")
+    def test_generate_tool_magres(
+        self, mock_generate_input_file, mock_MuonatedStructure, mock_GIPAWOutput
+    ):
+        # Don't supply a GIPAW file path while using a magres file with EFG
+        # tensors
+        structure = MuonatedStructure(StringIO(TEST_MAGRES_FILE_DATA), fmt="magres")
+        mock_MuonatedStructure.return_value = structure
+        _run_generator_tool(
+            [
+                "V3Si_SC.cell",
+                "6",
+                "--dipolar",
+                "--quadrupolar",
+            ]
+        )
+        mock_MuonatedStructure.assert_called_with("V3Si_SC.cell", muon_symbol="H")
+        mock_generate_input_file.assert_called_with(
+            GeneratorToolParams(
+                structure=mock_MuonatedStructure.return_value,
+                generators=[ANY, ANY],
+                number_closest=6,
+                additional_ignored_symbols=[],
+                max_layer=6,
             )
         )

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -86,7 +86,7 @@ class QuadrupoleIntGenerator(InteractionGenerator):
         self, muon_file_index: int, atom_file_index: int, atom: CellAtom
     ) -> str:
         # Obtain corresponding EFG tensor
-        efg_tensor = self._structure.get_efg_tensor(atom_file_index)
+        efg_tensor = self._structure.get_efg_tensor(atom.index)
 
         return f"""quadrupolar {atom_file_index}
     {' '.join(map(str, efg_tensor[0]))}


### PR DESCRIPTION
Modifies behaviour of muspinsim-gen so that it can take a magres file with EFG tensors defined. Then `muspinsim-gen` with `--quadrupolar` will attempt to use these tensors. `--quadrupolar GIPAW_OUTPUT_FILEPATH` will instead load them from the gipaw output file as before.

I also clarified with Leandro - the GIPAW file output was the result of using Quantum ESPRESSO, whereas the magres file came from CASTEP and we would like to be able to use either here.