### PR TITLE
Additional generator changes

### DIFF
--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -376,13 +376,16 @@ class MuonatedStructure:
         return self._efg_tensors[atom_index - 1]
 
     @property
-    def muon(self) -> List[str]:
+    def muon(self) -> CellAtom:
         """Returns the muon object from this structure"""
         return self._cell_atoms[self._muon_index]
 
     def move_atom(self, atom1: CellAtom, atom2: CellAtom, new_distance: float):
         """Moves atom2 to be a specific distance away from atom1, while preserving
         the direction between them
+
+        Useful for adjusting distances where DFT calculations may be
+        underestimating distances between the muon and its nearest neighbours
 
         Arguments:
             atom1 {CellAtom} -- Atom to compute the current distance from
@@ -415,6 +418,10 @@ class MuonatedStructure:
 
         atom2.position = new_pos
 
-        # Update the distance to the muon if necessary
+        # Update the distance to the muon (calculate if haven't already)
         if atom1 == self.muon:
             atom2.distance_from_muon = new_distance
+        else:
+            atom2.distance_from_muon = np.linalg.norm(
+                atom2.position - self.muon.position
+            )

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -18,18 +18,18 @@ class CellAtom:
 
     index: int  # Start from 1, unchanged when creating a supercell
     symbol: str
-    isotope: int
+    isotope: Optional[int]
     position: ArrayLike
     vector_from_muon: Optional[ArrayLike] = None
     distance_from_muon: Optional[float] = None
 
 
-def _get_isotope(mass: float, default_mass: float) -> int:
+def _get_isotope(mass: float, default_mass: float) -> Optional[int]:
     """
     Helper function to determine the isotope by comparing the found mass to
     the default of the same element
 
-    At the moment will not return anything other than 1 as there is no where
+    At the moment will not return anything other than None as there is nowhere
     to get the isotope masses from.
     """
 
@@ -37,7 +37,7 @@ def _get_isotope(mass: float, default_mass: float) -> int:
     if not math.isclose(mass, default_mass):
         raise ValueError("Failed to identify isotope by the given masses")
 
-    return 1
+    return None
 
 
 class MuonatedStructure:
@@ -139,8 +139,7 @@ class MuonatedStructure:
             # Keep track of any atoms with zero spin (so can exclude later)
             if (
                 loaded_atom.symbol not in self._symbols_zero_spin
-                and spin(elem=loaded_atom.symbol, iso=isotope if isotope > 1 else None)
-                == 0
+                and spin(elem=loaded_atom.symbol, iso=isotope) == 0
             ):
                 self._symbols_zero_spin.append(loaded_atom.symbol)
 

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -404,7 +404,7 @@ class MuonatedStructure:
         new_pos = atom1.position + ((new_distance / distance) * vector_between)
 
         # Log what is happening so can keep track
-        logging.warning(
+        logging.info(
             "Moving %s from %s to %s, changing the distance from %s to %s",
             atom2.symbol,
             atom2.position,

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -376,7 +376,7 @@ class MuonatedStructure:
             efg_tensor {ArrayLike}: EFG tensor for the atom at the given index
         """
         return self._efg_tensors[atom_index - 1]
-    
+
     @property
     def muon(self) -> List[str]:
         """Returns the muon object from this structure"""

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -379,3 +379,42 @@ class MuonatedStructure:
     def muon(self) -> List[str]:
         """Returns the muon object from this structure"""
         return self._cell_atoms[self._muon_index]
+
+    def move_atom(self, atom1: CellAtom, atom2: CellAtom, new_distance: float):
+        """Moves atom2 to be a specific distance away from atom1, while preserving
+        the direction between them
+
+        Arguments:
+            atom1 {CellAtom} -- Atom to compute the current distance from
+            atom2 {CellAtom} -- Atom that will be moved
+            new_distance {float} -- New distance that should be between the
+                                    atoms after moving
+
+        Raised:
+            NotImplementedError: If atom2 is the muon (All the other positions would
+                        need recalculating otherwise)
+        """
+        if atom2 == self.muon:
+            raise NotImplementedError("Moving the muon is not supported")
+
+        vector_between = atom2.position - atom1.position
+        distance = np.linalg.norm(vector_between)
+
+        # old_pos + new_dist * direction
+        new_pos = atom1.position + ((new_distance / distance) * vector_between)
+
+        # Log what is happening so can keep track
+        logging.warning(
+            "Moving %s from %s to %s, changing the distance from %s to %s",
+            atom2.symbol,
+            atom2.position,
+            new_pos,
+            distance,
+            new_distance,
+        )
+
+        atom2.position = new_pos
+
+        # Update the distance to the muon if necessary
+        if atom1 == self.muon:
+            atom2.distance_from_muon = new_distance

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -376,3 +376,8 @@ class MuonatedStructure:
             efg_tensor {ArrayLike}: EFG tensor for the atom at the given index
         """
         return self._efg_tensors[atom_index - 1]
+    
+    @property
+    def muon(self) -> List[str]:
+        """Returns the muon object from this structure"""
+        return self._cell_atoms[self._muon_index]

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -20,7 +20,6 @@ class CellAtom:
     symbol: str
     isotope: Optional[int]
     position: ArrayLike
-    vector_from_muon: Optional[ArrayLike] = None
     distance_from_muon: Optional[float] = None
 
 
@@ -259,8 +258,7 @@ class MuonatedStructure:
         muon = self._cell_atoms[self._muon_index]
 
         for atom in atoms:
-            atom.vector_from_muon = muon.position - atom.position
-            atom.distance_from_muon = np.linalg.norm(atom.vector_from_muon)
+            atom.distance_from_muon = np.linalg.norm(muon.position - atom.position)
 
     def compute_closest(
         self,

--- a/muspinsim/tests/test_generator.py
+++ b/muspinsim/tests/test_generator.py
@@ -94,6 +94,7 @@ class TestGenerator(unittest.TestCase):
                 ),
             ],
             number_closest=4,
+            include_interatomic=False,
             additional_ignored_symbols=[],
         )
 
@@ -102,30 +103,30 @@ class TestGenerator(unittest.TestCase):
             input_file_text,
             """spins
     mu V V Si Si
-dipolar 1 2
-    1.2410539563139198 1.7614965359999998e-05 -1.2417021305964
 quadrupolar 2
     -0.008877 2.2e-05 -0.011811
     2.2e-05 -0.030585 5e-06
     -0.011811 5e-06 0.039462
-dipolar 1 3
-    3.5524979205813603 1.7657510159999996e-05 3.5562763937592
+dipolar 1 2
+    1.2410539563139198 1.7614965359999998e-05 -1.2417021305964
 quadrupolar 3
     0.221597 -2e-06 -0.009013
     -2e-06 -0.109627 -9e-06
     -0.009013 -9e-06 -0.11197
+dipolar 1 3
+    3.5524979205813603 1.7657510159999996e-05 3.5562763937592
+quadrupolar 4
+    -0.002604 -0.0 -1e-06
+    -0.0 -0.002551 -9e-06
+    -1e-06 -9e-06 0.005154
 dipolar 1 4
     -4.72192610499264 2.366426252954879 3.54776669347968
-quadrupolar 4
+quadrupolar 5
     -0.002604 -0.0 -1e-06
     -0.0 -0.002551 -9e-06
     -1e-06 -9e-06 0.005154
 dipolar 1 5
     9.45967389500736 2.366426252954879 3.54776669347968
-quadrupolar 5
-    -0.002604 -0.0 -1e-06
-    -0.0 -0.002551 -9e-06
-    -1e-06 -9e-06 0.005154
 """,
         )
 
@@ -137,30 +138,76 @@ quadrupolar 5
             input_file_text,
             """spins
     mu V V V V
-dipolar 1 2
-    1.2410539563139198 1.7614965359999998e-05 -1.2417021305964
 quadrupolar 2
     -0.008877 2.2e-05 -0.011811
     2.2e-05 -0.030585 5e-06
     -0.011811 5e-06 0.039462
+dipolar 1 2
+    1.2410539563139198 1.7614965359999998e-05 -1.2417021305964
+quadrupolar 3
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
 dipolar 1 3
     3.5524979205813603 1.7657510159999996e-05 3.5562763937592
-quadrupolar 3
+quadrupolar 4
     0.221597 -2e-06 -0.009013
     -2e-06 -0.109627 -9e-06
     -0.009013 -9e-06 -0.11197
 dipolar 1 4
     3.5524979205813603 1.7657510159999996e-05 -10.6253236062408
-quadrupolar 4
+quadrupolar 5
     0.221597 -2e-06 -0.009013
     -2e-06 -0.109627 -9e-06
     -0.009013 -9e-06 -0.11197
 dipolar 1 5
     -10.62910207941864 1.7657510159999996e-05 3.5562763937592
+""",
+        )
+
+        # Include interatomic interactions
+        generate_params.include_interatomic = True
+        input_file_text = generate_input_file(generate_params)
+        self.assertEqual(
+            input_file_text,
+            """spins
+    mu V V V V
+quadrupolar 2
+    -0.008877 2.2e-05 -0.011811
+    2.2e-05 -0.030585 5e-06
+    -0.011811 5e-06 0.039462
+dipolar 1 2
+    1.2410539563139198 1.7614965359999998e-05 -1.2417021305964
+dipolar 2 3
+    2.3114439642674407 4.25447999999999e-08 4.7979785243555995
+dipolar 2 4
+    2.3114439642674407 4.25447999999999e-08 -9.3836214756444
+dipolar 2 5
+    -11.87015603573256 4.25447999999999e-08 4.7979785243555995
+quadrupolar 3
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
+dipolar 1 3
+    3.5524979205813603 1.7657510159999996e-05 3.5562763937592
+dipolar 3 4
+    0.0 0.0 -14.1816
+dipolar 3 5
+    -14.1816 0.0 0.0
+quadrupolar 4
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
+dipolar 1 4
+    3.5524979205813603 1.7657510159999996e-05 -10.6253236062408
+dipolar 4 5
+    -14.1816 0.0 14.1816
 quadrupolar 5
     0.221597 -2e-06 -0.009013
     -2e-06 -0.109627 -9e-06
     -0.009013 -9e-06 -0.11197
+dipolar 1 5
+    -10.62910207941864 1.7657510159999996e-05 3.5562763937592
 """,
         )
 
@@ -174,6 +221,7 @@ quadrupolar 5
                 QuadrupoleIntGenerator(structure),
             ],
             number_closest=4,
+            include_interatomic=False,
             additional_ignored_symbols=[],
         )
 
@@ -182,30 +230,30 @@ quadrupolar 5
             input_file_text,
             """spins
     mu V V Si Si
-dipolar 1 2
-    1.2410539564 1.7615e-05 -1.2417021433000002
 quadrupolar 2
     -0.008877 2.2e-05 -0.011811
     2.2e-05 -0.030585 5e-06
     -0.011811 5e-06 0.039462
-dipolar 1 3
-    3.5524979200999995 1.7657499999999998e-05 3.556276380799999
+dipolar 1 2
+    1.2410539564 1.7615e-05 -1.2417021433000002
 quadrupolar 3
     0.221597 -2e-06 -0.009013
     -2e-06 -0.109627 -9e-06
     -0.009013 -9e-06 -0.11197
+dipolar 1 3
+    3.5524979200999995 1.7657499999999998e-05 3.556276380799999
+quadrupolar 4
+    -0.002604 -0.0 -1e-06
+    -0.0 -0.002551 -9e-06
+    -1e-06 -9e-06 0.005154
 dipolar 1 4
     -4.7219261049 2.3664262525 3.5477666807999997
-quadrupolar 4
+quadrupolar 5
     -0.002604 -0.0 -1e-06
     -0.0 -0.002551 -9e-06
     -1e-06 -9e-06 0.005154
 dipolar 1 5
     9.4596738951 2.3664262525 3.5477666807999997
-quadrupolar 5
-    -0.002604 -0.0 -1e-06
-    -0.0 -0.002551 -9e-06
-    -1e-06 -9e-06 0.005154
 """,
         )
 
@@ -217,30 +265,77 @@ quadrupolar 5
             input_file_text,
             """spins
     mu V V V V
-dipolar 1 2
-    1.2410539564 1.7615e-05 -1.2417021433000002
 quadrupolar 2
     -0.008877 2.2e-05 -0.011811
     2.2e-05 -0.030585 5e-06
     -0.011811 5e-06 0.039462
+dipolar 1 2
+    1.2410539564 1.7615e-05 -1.2417021433000002
+quadrupolar 3
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
 dipolar 1 3
     3.5524979200999995 1.7657499999999998e-05 3.556276380799999
-quadrupolar 3
+quadrupolar 4
     0.221597 -2e-06 -0.009013
     -2e-06 -0.109627 -9e-06
     -0.009013 -9e-06 -0.11197
 dipolar 1 4
     3.5524979200999995 1.7657499999999998e-05 -10.6253236192
-quadrupolar 4
+quadrupolar 5
     0.221597 -2e-06 -0.009013
     -2e-06 -0.109627 -9e-06
     -0.009013 -9e-06 -0.11197
 dipolar 1 5
     -10.6291020799 1.7657499999999998e-05 3.556276380799999
+""",
+        )
+
+        # Include interatomic interactions
+        generate_params.include_interatomic = True
+        input_file_text = generate_input_file(generate_params)
+        print(input_file_text)
+        self.assertEqual(
+            input_file_text,
+            """spins
+    mu V V V V
+quadrupolar 2
+    -0.008877 2.2e-05 -0.011811
+    2.2e-05 -0.030585 5e-06
+    -0.011811 5e-06 0.039462
+dipolar 1 2
+    1.2410539564 1.7615e-05 -1.2417021433000002
+dipolar 2 3
+    2.3114439636999995 4.2500000000000017e-08 4.7979785240999995
+dipolar 2 4
+    2.3114439636999995 4.2500000000000017e-08 -9.3836214759
+dipolar 2 5
+    -11.8701560363 4.2500000000000017e-08 4.7979785240999995
+quadrupolar 3
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
+dipolar 1 3
+    3.5524979200999995 1.7657499999999998e-05 3.556276380799999
+dipolar 3 4
+    0.0 0.0 -14.1816
+dipolar 3 5
+    -14.1816 0.0 0.0
+quadrupolar 4
+    0.221597 -2e-06 -0.009013
+    -2e-06 -0.109627 -9e-06
+    -0.009013 -9e-06 -0.11197
+dipolar 1 4
+    3.5524979200999995 1.7657499999999998e-05 -10.6253236192
+dipolar 4 5
+    -14.1816 0.0 14.1816
 quadrupolar 5
     0.221597 -2e-06 -0.009013
     -2e-06 -0.109627 -9e-06
     -0.009013 -9e-06 -0.11197
+dipolar 1 5
+    -10.6291020799 1.7657499999999998e-05 3.556276380799999
 """,
         )
 
@@ -277,6 +372,7 @@ quadrupolar 5
                 ),
             ],
             number_closest=4,
+            include_interatomic=False,
             additional_ignored_symbols=[],
         )
 
@@ -303,6 +399,7 @@ quadrupolar 5
                 structure=mock_MuonatedStructure.return_value,
                 generators=[ANY],
                 number_closest=4,
+                include_interatomic=False,
                 additional_ignored_symbols=[],
                 max_layer=6,
             )
@@ -338,6 +435,7 @@ quadrupolar 5
                 structure=mock_MuonatedStructure.return_value,
                 generators=[ANY, ANY],
                 number_closest=6,
+                include_interatomic=False,
                 additional_ignored_symbols=["Si", "F"],
                 max_layer=3,
             )
@@ -388,6 +486,25 @@ quadrupolar 5
                 structure=mock_MuonatedStructure.return_value,
                 generators=[ANY, ANY],
                 number_closest=6,
+                include_interatomic=False,
+                additional_ignored_symbols=[],
+                max_layer=6,
+            )
+        )
+
+    @patch("muspinsim.tools.generator.MuonatedStructure")
+    @patch("muspinsim.tools.generator.generate_input_file")
+    def test_generate_tool_include_interatomic(
+        self, mock_generate_input_file, mock_MuonatedStructure
+    ):
+        _run_generator_tool(["V3Si_SC.cell", "4", "--dipolar", "--include_interatomic"])
+        mock_MuonatedStructure.assert_called_with("V3Si_SC.cell", muon_symbol="H")
+        mock_generate_input_file.assert_called_with(
+            GeneratorToolParams(
+                structure=mock_MuonatedStructure.return_value,
+                generators=[ANY],
+                number_closest=4,
+                include_interatomic=True,
                 additional_ignored_symbols=[],
                 max_layer=6,
             )

--- a/muspinsim/tests/test_structure.py
+++ b/muspinsim/tests/test_structure.py
@@ -83,9 +83,6 @@ class CellAtomMatcher:
             self.expected.index == other.index
             and self.expected.symbol == other.symbol
             and _optional_array_close(self.expected.position, other.position)
-            and _optional_array_close(
-                self.expected.vector_from_muon, other.vector_from_muon
-            )
             and _optional_float_close(
                 self.expected.distance_from_muon, other.distance_from_muon
             )
@@ -106,7 +103,6 @@ class TestStructure(unittest.TestCase):
                 symbol="Si",
                 isotope=1,
                 position=np.array([7.08553473, 11.81519966, 11.81563156]),
-                vector_from_muon=None,
                 distance_from_muon=None,
             ),
         )
@@ -125,7 +121,6 @@ class TestStructure(unittest.TestCase):
                 symbol="Si",
                 isotope=1,
                 position=np.array([7.08553473, 11.81519966, 11.81563156]),
-                vector_from_muon=None,
                 distance_from_muon=None,
             ),
         )
@@ -281,7 +276,6 @@ H             0.1666672745        0.0000018274        0.0833332099
                 symbol="Si",
                 isotope=1,
                 position=np.array([-7.09606527, 11.81519966, -2.36596844]),
-                vector_from_muon=None,
                 distance_from_muon=None,
             ),
         )
@@ -298,7 +292,6 @@ H             0.1666672745        0.0000018274        0.0833332099
                 symbol="V",
                 isotope=1,
                 position=np.array([-1.18888930e00, 8.25794568e-06, 2.59887219e01]),
-                vector_from_muon=None,
                 distance_from_muon=None,
             ),
         )
@@ -315,9 +308,6 @@ H             0.1666672745        0.0000018274        0.0833332099
                 symbol="V",
                 isotope=1,
                 position=np.array([1.12255466e00, 8.30049048e-06, 2.42350038e00]),
-                vector_from_muon=np.array(
-                    [1.24105396e00, 1.76149654e-05, -1.24170213e00]
-                ),
                 distance_from_muon=1.7555737250028431,
             ),
         )
@@ -333,9 +323,6 @@ H             0.1666672745        0.0000018274        0.0833332099
                 symbol="V",
                 isotope=1,
                 position=np.array([1.29927107e01, 8.25794568e-06, -2.37447814e00]),
-                vector_from_muon=np.array(
-                    [-1.06291021e01, 1.76575102e-05, 3.55627639e00]
-                ),
                 distance_from_muon=11.208251995910084,
             ),
         )

--- a/muspinsim/tests/test_structure.py
+++ b/muspinsim/tests/test_structure.py
@@ -327,8 +327,37 @@ H             0.1666672745        0.0000018274        0.0833332099
             ),
         )
 
-    def test_compute_closest_max_layer(self):
+    def test_move_atom(self):
         structure = MuonatedStructure(StringIO(TEST_CELL_FILE_DATA), fmt="castep-cell")
+        closest_atoms = structure.compute_closest(1)
 
-        with self.assertRaises(RuntimeError):
-            structure.compute_closest(6, max_layer=1)
+        # Before moving
+        self.assertEqual(
+            CellAtomMatcher(closest_atoms[0]),
+            CellAtom(
+                index=1,
+                symbol="V",
+                isotope=1,
+                position=np.array([1.12255466e00, 8.30049048e-06, 2.42350038e00]),
+                distance_from_muon=1.7555737250028431,
+            ),
+        )
+
+        # After moving
+        structure.move_atom(structure.muon, closest_atoms[0], 1)
+        print(closest_atoms[0])
+        self.assertEqual(
+            CellAtomMatcher(closest_atoms[0]),
+            CellAtom(
+                index=1,
+                symbol="V",
+                isotope=1,
+                position=np.array([1.65668647e00, 1.58817187e-05, 1.88908961e0]),
+                distance_from_muon=1.0,
+            ),
+        )
+        self.assertTrue(
+            np.isclose(
+                np.linalg.norm(closest_atoms[0].position - structure.muon.position), 1.0
+            )
+        )

--- a/muspinsim/tests/test_structure.py
+++ b/muspinsim/tests/test_structure.py
@@ -361,3 +361,7 @@ H             0.1666672745        0.0000018274        0.0833332099
                 np.linalg.norm(closest_atoms[0].position - structure.muon.position), 1.0
             )
         )
+
+        # Should raise error if trying to move the muon
+        with self.assertRaises(NotImplementedError):
+            structure.move_atom(closest_atoms[0], structure.muon, 1)

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -68,7 +68,8 @@ class QuadrupoleIntGeneratorGIPAWOut(InteractionGenerator):
 
         if gipaw_atom is None:
             raise ValueError(
-                f"Unable to locate atom with index {atoms[0].index} in GIPAW output file"
+                f"""Unable to locate atom with index {atoms[0].index} in GIPAW
+output file"""
             )
         efg_tensor = gipaw_atom.efg_tensor
 
@@ -190,7 +191,10 @@ def generate_input_file_from_selection(
 
                 input_file += f"""{
                     generator.gen_config(
-                        atom_file_indices=[selected_atom1_file_index, selected_atom2_file_index],
+                        atom_file_indices=[
+                            selected_atom1_file_index,
+                            selected_atom2_file_index
+                        ],
                         atoms=[selected_atom1, selected_atom2],
                     )
                 }\n"""

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -130,25 +130,17 @@ class GeneratorToolParams:
     max_layer: int = 6
 
 
-def generate_input_file(params: GeneratorToolParams) -> str:
-    """Utility function for generating muspinsim input config given a
-    structure as input
-
-    Will expand the muonated structure by the amount requested and
-    locate the nearest neighbours in order to generate their interactions
-    for the config file.
+def generate_input_file_from_selection(
+    params: GeneratorToolParams, selected_atoms: List[CellAtom]
+) -> str:
+    """Utility function for generating muspinsim from a list of selected atoms
+    obtained from a structure
 
     Arguments:
         params {GeneratorToolParams} -- Parameters (see above for details)
+        selected_atoms {List[CellAtom]} -- Selected atoms to be included in
+                                           the generated config
     """
-
-    # Locate closest elements (ignoring ones with zero spin)
-    selected_atoms = params.structure.compute_closest(
-        number=params.number_closest,
-        ignored_symbols=params.structure.symbols_zero_spin
-        + params.additional_ignored_symbols,
-        max_layer=params.max_layer,
-    )
 
     selected_symbols = "mu"
     input_file = ""
@@ -208,6 +200,30 @@ def generate_input_file(params: GeneratorToolParams) -> str:
 {input_file}"""
 
     return input_file
+
+
+def generate_input_file(params: GeneratorToolParams) -> str:
+    """Utility function for generating muspinsim input config given a
+    structure as input
+
+    Will expand the muonated structure by the amount requested and
+    locate the nearest neighbours in order to generate their interactions
+    for the config file.
+
+    Arguments:
+        params {GeneratorToolParams} -- Parameters (see above for details)
+    """
+
+    return generate_input_file_from_selection(
+        params,
+        # Locate closest elements (ignoring ones with zero spin)
+        params.structure.compute_closest(
+            number=params.number_closest,
+            ignored_symbols=params.structure.symbols_zero_spin
+            + params.additional_ignored_symbols,
+            max_layer=params.max_layer,
+        ),
+    )
 
 
 def _run_generator_tool(args):

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -149,8 +149,8 @@ def generate_input_file(params: GeneratorToolParams) -> str:
     for selected_atom in selected_atoms:
         symbol = selected_atom.symbol
 
-        if selected_atom.isotope != 1:
-            symbol = f"{str(selected_atom.isotope)} {symbol}"
+        if selected_atom.isotope is not None:
+            symbol = f"{str(selected_atom.isotope)}{symbol}"
 
         selected_symbols += f" {symbol}"
 

--- a/muspinsim/tools/generator.py
+++ b/muspinsim/tools/generator.py
@@ -15,19 +15,23 @@ class InteractionGenerator(ABC):
     config
     """
 
+    def __init__(self, num_inputs: int):
+        """
+        Number of atom indices expected as input for this generator e.g. 1 for
+        quadrupole or 2 for dipole
+        """
+        self.num_inputs = num_inputs
+
     @abstractmethod
-    def gen_config(
-        self, muon_file_index: int, atom_file_index: int, atom: CellAtom
-    ) -> str:
+    def gen_config(self, atom_file_indices: List[int], atoms: List[CellAtom]) -> str:
         """Should return the config required for an interaction between the muon
         and given atom using this generator
 
         Arguments:
-            muon_file_index {int} -- Index of the muon in the file (starts
-                                     from 1)
-            atom_file_index {int} -- Index of the atom in the file (starts
-                                     from 1)
-            atom {CellAtom} -- Atom to generate config for
+            atom_file_indices {List[int]} -- List of file indices for the
+                                             atoms given as input (starts at
+                                             1)
+            atoms {List[CellAtom]} -- Atoms to generate config for
         """
 
 
@@ -36,11 +40,14 @@ class DipoleIntGenerator(InteractionGenerator):
     Generator for the dipole interaction
     """
 
-    def gen_config(
-        self, muon_file_index: int, atom_file_index: int, atom: CellAtom
-    ) -> str:
-        return f"""dipolar {muon_file_index} {atom_file_index}
-    {" ".join(map(str, atom.vector_from_muon))}"""
+    def __init__(self):
+        super().__init__(num_inputs=2)
+
+    def gen_config(self, atom_file_indices: List[int], atoms: List[CellAtom]) -> str:
+        vector_between = atoms[0].position - atoms[1].position
+
+        return f"""dipolar {atom_file_indices[0]} {atom_file_indices[1]}
+    {" ".join(map(str, vector_between))}"""
 
 
 class QuadrupoleIntGeneratorGIPAWOut(InteractionGenerator):
@@ -51,21 +58,21 @@ class QuadrupoleIntGeneratorGIPAWOut(InteractionGenerator):
     _gipaw_file: GIPAWOutput
 
     def __init__(self, gipaw_file: GIPAWOutput):
+        super().__init__(num_inputs=1)
+
         self._gipaw_file = gipaw_file
 
-    def gen_config(
-        self, muon_file_index: int, atom_file_index: int, atom: CellAtom
-    ) -> str:
+    def gen_config(self, atom_file_indices: List[int], atoms: List[CellAtom]) -> str:
         # Obtain corresponding EFG tensor
-        gipaw_atom = self._gipaw_file.find_atom(atom.index)
+        gipaw_atom = self._gipaw_file.find_atom(atoms[0].index)
 
         if gipaw_atom is None:
             raise ValueError(
-                f"Unable to locate atom with index {atom.index} in GIPAW output file"
+                f"Unable to locate atom with index {atoms[0].index} in GIPAW output file"
             )
         efg_tensor = gipaw_atom.efg_tensor
 
-        return f"""quadrupolar {atom_file_index}
+        return f"""quadrupolar {atom_file_indices[0]}
     {' '.join(map(str, efg_tensor[0]))}
     {' '.join(map(str, efg_tensor[1]))}
     {' '.join(map(str, efg_tensor[2]))}"""
@@ -80,15 +87,15 @@ class QuadrupoleIntGenerator(InteractionGenerator):
     _structure: MuonatedStructure
 
     def __init__(self, structure: MuonatedStructure):
+        super().__init__(num_inputs=1)
+
         self._structure = structure
 
-    def gen_config(
-        self, muon_file_index: int, atom_file_index: int, atom: CellAtom
-    ) -> str:
+    def gen_config(self, atom_file_indices: List[int], atoms: List[CellAtom]) -> str:
         # Obtain corresponding EFG tensor
-        efg_tensor = self._structure.get_efg_tensor(atom.index)
+        efg_tensor = self._structure.get_efg_tensor(atoms[0].index)
 
-        return f"""quadrupolar {atom_file_index}
+        return f"""quadrupolar {atom_file_indices[0]}
     {' '.join(map(str, efg_tensor[0]))}
     {' '.join(map(str, efg_tensor[1]))}
     {' '.join(map(str, efg_tensor[2]))}"""
@@ -103,6 +110,9 @@ class GeneratorToolParams:
         generators {List[InteractionGenerator]} -- List of generators for
                                                 generating interaction terms
         number_closest {int} -- Number of closest atoms to the muon to include
+        include_interatomic {bool} -- Whether to include interactions between
+                                      the atoms themselves (only applied to
+                                      generators taking 2 inputs)
         additional_ignored_symbols {List[str]} -- List of additional symbols
                                     to ignore when counting the closest atoms.
                                     All spin 0 isotopes will be ignored by
@@ -115,6 +125,7 @@ class GeneratorToolParams:
     structure: MuonatedStructure
     generators: List[InteractionGenerator]
     number_closest: int
+    include_interatomic: bool
     additional_ignored_symbols: List[str] = field(default_factory=list)
     max_layer: int = 6
 
@@ -139,31 +150,58 @@ def generate_input_file(params: GeneratorToolParams) -> str:
         max_layer=params.max_layer,
     )
 
-    # Generate input file
     selected_symbols = "mu"
-    muon_file_index = 1
-    atom_file_index = 2
-
     input_file = ""
+    muon = params.structure.muon
 
-    for selected_atom in selected_atoms:
-        symbol = selected_atom.symbol
+    # Split up generators based on how many inputs they take
+    single_input_generators = list(
+        filter(lambda generator: generator.num_inputs == 1, params.generators)
+    )
+    double_input_generators = list(
+        filter(lambda generator: generator.num_inputs == 2, params.generators)
+    )
 
-        if selected_atom.isotope is not None:
-            symbol = f"{str(selected_atom.isotope)}{symbol}"
+    for i, selected_atom1 in enumerate(selected_atoms):
+        selected_atom1_file_index = i + 2
+
+        # Include the symbol into the spin's section
+        symbol = selected_atom1.symbol
+
+        if selected_atom1.isotope is not None:
+            symbol = f"{str(selected_atom1.isotope)}{symbol}"
 
         selected_symbols += f" {symbol}"
 
-        for generator in params.generators:
+        # Append config for single generators (using currently selected atom)
+        for generator in single_input_generators:
             input_file += f"""{
                 generator.gen_config(
-                    muon_file_index,
-                    atom_file_index,
-                    selected_atom
+                    atom_file_indices=[selected_atom1_file_index],
+                    atoms=[selected_atom1],
                 )
             }\n"""
 
-        atom_file_index += 1
+        # Apply double input generators (with muon as first input)
+        for generator in double_input_generators:
+            input_file += f"""{
+                generator.gen_config(
+                    atom_file_indices=[1, selected_atom1_file_index],
+                    atoms=[muon, selected_atom1],
+                )
+            }\n"""
+
+        if params.include_interatomic:
+            # Apply double terms between the nuclei themselves
+            for j, selected_atom2 in enumerate(selected_atoms[i + 1 :], start=i + 1):
+                selected_atom2_file_index = j + 2
+
+                input_file += f"""{
+                    generator.gen_config(
+                        atom_file_indices=[selected_atom1_file_index, selected_atom2_file_index],
+                        atoms=[selected_atom1, selected_atom2],
+                    )
+                }\n"""
 
     input_file = f"""spins
     {selected_symbols}
@@ -209,6 +247,12 @@ def _run_generator_tool(args):
         help="""Specify to include quadrupolar couplings. If the given
 structure file is not a Magres file with EFG data a file path to a GIPAW
 output file will be required.""",
+    )
+    parser.add_argument(
+        "--include_interatomic",
+        dest="include_interatomic",
+        action="store_true",
+        help="Specify to include interactions between the atoms themselves.",
     )
     parser.add_argument(
         "--out",
@@ -272,6 +316,7 @@ GIPAW_OUTPUT_FILEPATH' or supply a Magres structure file with EFG's provided."""
         structure=structure,
         generators=generators,
         number_closest=args.number_closest,
+        include_interatomic=args.include_interatomic,
         additional_ignored_symbols=args.ignored_symbols,
         max_layer=args.max_layer,
     )


### PR DESCRIPTION
- Modifies default value of isotope in the atoms loaded in the structure file as None instead of 1 - I think this makes more sense and it means the isotope parameters can be obtained without needing any extra logic
- Adds a parameter --include_interatomic for adding interactions between the nuclei themselves
- Restructures the code slightly so I can insert Johnny's method for moving the nuclei prior to producing the output file

For context I have also committed my use of these changes to apply Johnny's method for moving the nn-F's here: https://github.com/muon-spectroscopy-computational-project/Developer-notes/blob/main/muspinsim/johnnys_method.py
I could add this to the PR as well if it seems appropriate but am unsure myself.