### PR TITLE
Fix some bugs with muspinsim-gen

### DIFF
--- a/muspinsim/input/gipaw.py
+++ b/muspinsim/input/gipaw.py
@@ -64,6 +64,8 @@ class GIPAWOutput:
             atom = self._parse_efg(lines)
             if atom is not None:
                 self._atoms.append(atom)
+            else:
+                break
 
             # Go to the next line
             file_io.readline()

--- a/muspinsim/input/gipaw.py
+++ b/muspinsim/input/gipaw.py
@@ -39,18 +39,24 @@ class GIPAWOutput:
             file_io = open(file_io, encoding="utf_8")
 
         # Attempt to skip to relevant part of the file
-        while not file_io.readline().strip().startswith("----- total EFG -----"):
-            continue
+        file_valid = False
 
-        loop = True
-        while loop:
+        while line := file_io.readline():
+            if line.strip().startswith("----- total EFG -----"):
+                file_valid = True
+                break
+
+        if not file_valid:
+            raise ValueError(f"Failed to load file GIPAW output file {file_io}")
+
+        while line := file_io.readline():
             # Should be 3 lines at a time per element e.g.
             #      V    1       -0.008879        0.000000       -0.011803
             #      V    1        0.000000       -0.030597        0.000000
             #      V    1       -0.011803        0.000000        0.039476
 
             lines = [
-                file_io.readline().strip(),
+                line.strip(),
                 file_io.readline().strip(),
                 file_io.readline().strip(),
             ]
@@ -58,8 +64,6 @@ class GIPAWOutput:
             atom = self._parse_efg(lines)
             if atom is not None:
                 self._atoms.append(atom)
-            else:
-                loop = False
 
             # Go to the next line
             file_io.readline()

--- a/muspinsim/input/structure.py
+++ b/muspinsim/input/structure.py
@@ -304,8 +304,8 @@ class MuonatedStructure:
             "Attempting to find the %s closest atoms to the muon in " "the structure",
             number,
         )
-        if ignored_symbols is not None:
-            logging.info("Ignoring the symbols %s", ", ".join(ignored_symbols))
+        if ignored_symbols:
+            logging.info("Ignoring the symbols: %s", ", ".join(ignored_symbols))
 
         while continue_expansion:
             # Sort by distance and obtain furthest distance of the desired

--- a/muspinsim/tests/test_gipaw.py
+++ b/muspinsim/tests/test_gipaw.py
@@ -62,6 +62,15 @@ class TestGIPAW(unittest.TestCase):
             ),
         )
 
+    def test_load_error(self):
+        with self.assertRaises(ValueError):
+            GIPAWOutput(
+                StringIO(
+                    """some random text
+                       with newlines"""
+                )
+            )
+
     def test_parsing_errors(self):
         with self.assertRaises(ValueError):
             GIPAWOutput(


### PR DESCRIPTION
Fixes two things

- muspinsim-gen without any ignored_symbol resulted in a log "Ignoring the symbols" (condition previously only checked for None, but in this case it was an empty list)
- Specifying an invalid gipaw output file for --quadrupolar resulted in an infinite loop as `readline` just infinitely returns empty lines