### PR TITLE
Add error multiple definitions of the same block #71

### DIFF
--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -49,8 +49,8 @@ y_axis
 
 def write_error(keyword, block_line_num, err):
     return (
-        "Error occurred when parsing keyword '{0}' "
-        "(block starting at line {1}):\n{2}".format(keyword, block_line_num, str(err))
+        f"Error occurred when parsing keyword '{keyword}' "
+        f"(block starting at line {block_line_num}):\n{str(err)}"
     )
 
 
@@ -77,18 +77,20 @@ def _make_blocks(file_stream):
             if indent is None:
                 indent = m.groups()[0]
             if m.groups()[0] != indent:
-                raise RuntimeError("Invalid indent in input file")
+                raise MuSpinInputError("Invalid indent in input file")
             else:
                 try:
                     raw_blocks[curr_block].append(l.strip())
                 except KeyError as exc:
-                    raise RuntimeError("Badly formatted input file") from exc
+                    raise MuSpinInputError("Badly formatted input file") from exc
         else:
             curr_block = l.strip()
 
             # Check if the block has already been defined before
             if curr_block in raw_blocks:
-                raise RuntimeError(f"Redefinition of '{curr_block}' in input file")
+                raise MuSpinInputError(
+                    f"Redefinition of '{curr_block}' found in input file"
+                )
 
             raw_blocks[curr_block] = []
             block_line_nums[curr_block] = i + 1

--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -85,6 +85,11 @@ def _make_blocks(file_stream):
                     raise RuntimeError("Badly formatted input file") from exc
         else:
             curr_block = l.strip()
+
+            # Check if the block has already been defined before
+            if curr_block in raw_blocks:
+                raise RuntimeError(f"Redefinition of '{curr_block}' in input file")
+
             raw_blocks[curr_block] = []
             block_line_nums[curr_block] = i + 1
             indent = None  # Reset for each block

--- a/muspinsim/simconfig.py
+++ b/muspinsim/simconfig.py
@@ -131,12 +131,10 @@ class MuSpinConfig:
 
             try:
                 p = params[iname]
-            except KeyError:
+            except KeyError as exc:
                 raise MuSpinConfigError(
-                    "Invalid params object passed to "
-                    "MuSpinConfig: "
-                    "missing {0}".format(iname)
-                )
+                    f"Invalid params object passed to MuSpinConfig: missing {iname}"
+                ) from exc
 
             v = self.validate(cname, p.value, p.args)
 


### PR DESCRIPTION
Adds an error as discussed on https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/pull/132, resulting in errors of the form

![image](https://user-images.githubusercontent.com/90245114/224336954-fcb5923b-8280-47e1-9f94-1910dfe5e48c.png)

when defining an input file with
```
hyperfine 2
    580 5   10
    5   580 9
    10  9   580
hyperfine 2
    150 3   4
    3   150 5
    4   5   150
```

Also modifies two other errors for invalid indents and invalid formatting to be of type MuSpinInputError instead of RuntimeError.

Closes #71 