### PR TITLE
Add 'results_function' parameter for improving fitting capabilities #77

### DIFF
--- a/docs/docs/input.md
+++ b/docs/docs/input.md
@@ -364,7 +364,7 @@ fitting_method
     lbfgs
 ```
 
-Method to use to fit the data. Currently available are only `nelder-mead` (default) and `lbfgs`.
+Method to use to fit the data. Currently available are `nelder-mead` (default), `lbfgs` and `least-squares`.
 
 ### fitting_tolerance
 
@@ -381,7 +381,7 @@ fitting_tolerance
     1e-4
 ```
 
-Tolerance for the fitting. Used as the `tol` parameter in Scipy's `scipy.optimize.minimize` method; exact meaning depends on fitting method. Check the [Scipy documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html) for further details.
+Tolerance for the fitting. When using `nelder-mead` (default) or `lbfgs` it's used as the `tol` parameter in SciPy's `scipy.optimize.minimize` method; exact meaning depends on which of these are used. Check the [SciPy documentation here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html) for further details on these. Alternatively for `least-squares` it represents the `gtol` parameter as found in the [SciPy documentation here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.least_squares.html)
 
 ### experiment
 

--- a/docs/docs/input.md
+++ b/docs/docs/input.md
@@ -311,11 +311,14 @@ A function that should be applied on the results of a simulation it has two spec
 *Example:*
 ```plaintext
 fitting_variables
-    x
-    y  1.0  0.0 5.0
+    A
+    B  1.0  0.0 5.0
 ```
 
 Variables to fit to the experimental data. If present, the calculation is assumed to be a fitting, and the `fitting_data` keyword must be present too. The first letter in each row is the name of the variable; optionally, it can be followed in order by the starting value of the variable, the minimum bound, and the maximum bound (by default `0`, `-inf` and `+inf`). It is important to notice that while expressions are accepted in the definition of value, minimum, and maximum, these can not contain the name of other variables.
+
+!!! caution
+    Sometimes the fitting may converge to values you don't expect. To resolve this try specifying the starting value or assigning suitable bounds for the parameter.
 
 These variables can also be combined with `results_function` to perform fitting on the simulation results e.g.
 

--- a/docs/docs/input.md
+++ b/docs/docs/input.md
@@ -58,7 +58,7 @@ and the following functions:
 * `log(x)`: natural logarithm
 * `sqrt(x)`: square root
 
-These are all reserved names and can't be used as variable names.
+These are all reserved names and can't be used as variable names. There are also other reserved variable names `x` and `y` only for use with the `results_function` keyword.
 
 ### Using multiple lines for a keyword
 
@@ -281,6 +281,24 @@ temperature
 
 Temperature in Kelvin of the system. This is used to determine the initial density matrix of the system, as every spin that is not the muon is put in a thermal state, and in case of dissipative systems, to determine the coupling to the thermal bath. By default, it is set to infinity. A warning: both density matrices and dissipative couplings for finite temperatures are only calculated approximatively, based on the individual Hamiltonians for each spin which only account for the applied magnetic field. In other words, these approximations are meant for high field experiments, and break down in the low field regime. Therefore, caution should be used when changing this variable or interpreting the resulting simulations.
 
+### results_function
+
+| Keyword:                  |         `results_function` |
+|---------------------------|---------------------------:|
+| Allows multiple rows:     |                        No  |
+| Allows expressions:       |                        Yes |
+| Allows constants:         | default, `muon_gyr`, `MHz` |
+| Allows functions:         |                    default |
+| Allows special variables: |                   `x`, `y` |
+
+*Example:*
+```plaintext
+results_function
+    2*y
+```
+
+A function that should be applied on the results of a simulation it has two special variables available to it, `x` and `y` representing the x and y outputs of running a simulation (see [x_axis](#x_axis) and [y_axis](#y_axis)). The default value of `y` has no effect on the results.
+
 ### fitting_variables
 | Keyword:              |        `fitting_variables` |
 |-----------------------|---------------------------:|
@@ -298,6 +316,19 @@ fitting_variables
 ```
 
 Variables to fit to the experimental data. If present, the calculation is assumed to be a fitting, and the `fitting_data` keyword must be present too. The first letter in each row is the name of the variable; optionally, it can be followed in order by the starting value of the variable, the minimum bound, and the maximum bound (by default `0`, `-inf` and `+inf`). It is important to notice that while expressions are accepted in the definition of value, minimum, and maximum, these can not contain the name of other variables.
+
+These variables can also be combined with `results_function` to perform fitting on the simulation results e.g.
+
+```plaintext
+fitting_variables
+    A 1
+    B 1
+results_function
+    Ax+B
+```
+
+!!! note
+    When all defined `fitting_variables` are used only in `results_function` the simulation will only be run once. But when introducing any fitting parameters elsewhere the simulation will run for each new combination of parameters during fitting which may take a lot longer for large systems.
 
 ### fitting_data
 
@@ -348,7 +379,6 @@ fitting_tolerance
 ```
 
 Tolerance for the fitting. Used as the `tol` parameter in Scipy's `scipy.optimize.minimize` method; exact meaning depends on fitting method. Check the [Scipy documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html) for further details.
-
 
 ### experiment
 

--- a/docs/docs/input.md
+++ b/docs/docs/input.md
@@ -345,7 +345,7 @@ results_function
 *Example:*
 ```plaintext
 fitting_data
-    load('results.dat')
+    load("results.dat")
 ```
 
 Block of data to fit. Must have two columns: the first one is the `x_axis` (for example, time), while the second is the expected result of the simulation. The function `load` can be used to load it from an ASCII tabulated file on disk, as long as it has only two columns. Note that the data must be normalized properly to match the conventions of MuSpinSim's output, so for example it must start from 0.5 at t = 0 (as that's the moment of the muon before it has had any time to evolve).

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -125,8 +125,10 @@ def main(use_mpi=False):
     else:
         in_file = MuSpinInput()
         is_fitting = False
+        out_path = None
 
     is_fitting = mpi.broadcast(is_fitting)
+    out_path = mpi.broadcast(out_path)
 
     if not is_fitting:
         # No fitting

--- a/muspinsim/celio.py
+++ b/muspinsim/celio.py
@@ -18,8 +18,11 @@ from muspinsim.cpp import (
     Celio_EvolveContrib,
     celio_evolve,
 )
-from muspinsim.spinop import SpinOperator
-from muspinsim.validation import validate_evolve_params, validate_times
+from muspinsim.validation import (
+    validate_evolve_params,
+    validate_times,
+    validate_celio_params,
+)
 
 
 @dataclass
@@ -235,13 +238,9 @@ class CelioHamiltonian:
             operators = []
 
         times = np.array(times)
-        if isinstance(operators, SpinOperator):
-            operators = [operators]
 
         validate_evolve_params(rho0, times, operators)
-
-        if len(self._terms) == 0:
-            raise ValueError("No interaction terms to evolve")
+        validate_celio_params(self._terms, times)
 
         time_step = times[1] - times[0]
         rho0 = rho0.matrix
@@ -350,12 +349,10 @@ class CelioHamiltonian:
         times = np.array(times)
 
         validate_times(times)
+        validate_celio_params(self._terms, times)
 
         if averages <= 0:
             raise ValueError("averages must be a positive integer")
-
-        if len(self._terms) == 0:
-            raise ValueError("No interaction terms to evolve")
 
         # Due to computation of of psi we assume the muon is first in
         # the system so ensure this is the case here, otherwise

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -35,10 +35,10 @@ class ExperimentRunner:
             in_file {MuSpinInput} -- The input file object defining the
                                     calculations we need to perform.
             variables {dict} -- The values of any variables appearing in the input
-                                file. When specified it will be assumed that we
-                                are running a fitting calculation and
-                                results_function will not be used when 'run' is
-                                called.
+                                file. Should only be specified when
+                                running a fitting calculation, in which case
+                                results_function will not be applied when 'run' is
+                                called as it is already applied by the FittingRunner.
         """
         # Fix W0102:dangerous-default-value
         if variables is None:
@@ -331,7 +331,7 @@ class ExperimentRunner:
     def p_operator(self):
         return self._system.muon_operator(self.p)
 
-    def _apply_results_function(self, results: ArrayLike, variables: dict):
+    def apply_results_function(self, results: ArrayLike, variables: dict):
         # We expect muspinsim to output arrays with shape N here
         # but the evaluation will return an array with shape (1, N) instead
         return np.array(
@@ -361,7 +361,7 @@ class ExperimentRunner:
         # FittingRunner handle it so we can optimise and avoid repeated calls
         # to this function)
         if not self._variables:
-            results = self._apply_results_function(results, self._variables)
+            results = self.apply_results_function(results, {})
 
         self._config.results = results
         return self._config.results

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -36,7 +36,9 @@ class ExperimentRunner:
                                     calculations we need to perform.
             variables {dict} -- The values of any variables appearing in the input
                                 file. When specified it will be assumed that we
-                                are running a fitting calculation.
+                                are running a fitting calculation and
+                                results_function will not be used when 'run' is
+                                called.
         """
         # Fix W0102:dangerous-default-value
         if variables is None:

--- a/muspinsim/fitting.py
+++ b/muspinsim/fitting.py
@@ -85,8 +85,8 @@ class FittingRunner:
             # As we are fitting, the config will only contain the results
             # prior to the applying results_function, so update the actual
             # values now
-            self._runner._config.results = self._runner._apply_results_function(
-                self._runner._config.results, dict(zip(self._xnames, self._x))
+            self._runner.config.results = self._runner._apply_results_function(
+                self._runner.config.results, dict(zip(self._xnames, self._sol["x"]))
             )
 
             # And now save the last result
@@ -154,30 +154,26 @@ class FittingRunner:
                 fname = config.name + "_fit_report.txt"
 
             with open(os.path.join(path, fname), "w", encoding="utf-8") as file:
-                file.write("Fitting process for {0} completed\n".format(config.name))
-                file.write("Success achieved: {0}\n".format(self._sol["success"]))
+                file.write(f"Fitting process for {config.name} completed\n")
+                file.write(f"Success achieved: {self._sol['success']}\n")
                 if not self._sol["success"]:
-                    file.write("   Message: {0}\n".format(self._sol["message"]))
+                    file.write(f"   Message: {self._sol['message']}\n")
 
-                file.write(
-                    "Final absolute error <|f-f_targ|>: "
-                    "{0}\n".format(self._sol["fun"])
-                )
+                file.write(f"Final absolute error <|f-f_targ|>: {self._sol['fun']}\n")
                 num_simulations = self._sol["nfev"]
                 if self._fitinfo["single_simulation"]:
                     num_simulations = 1
                     file.write(
-                        "Number of 'results_function' evaluations: {0}\n".format(
-                            self._sol["nfev"]
-                        )
+                        "Number of 'results_function' evaluations: "
+                        f"{self._sol['nfev']}\n"
                     )
-                file.write("Number of simulations: {0}\n".format(num_simulations))
-                file.write("Number of iterations: {0}\n".format(self._sol["nit"]))
+                file.write(f"Number of simulations: {num_simulations}\n")
+                file.write(f"Number of iterations: {self._sol['nit']}\n")
 
                 file.write("\n" + "=" * 20 + "\n")
                 file.write("\nValues found for fitting variables:\n\n")
                 for name, val in variables.items():
-                    file.write("\t{0} = {1}\n".format(name, val))
+                    file.write(f"\t{name} = {val}\n")
 
     @property
     def solution(self):

--- a/muspinsim/fitting.py
+++ b/muspinsim/fitting.py
@@ -3,7 +3,6 @@
 A class that takes care of runs where the goal is to fit some given data"""
 
 import os
-import sys
 import numpy as np
 from scipy.optimize import minimize
 

--- a/muspinsim/fitting.py
+++ b/muspinsim/fitting.py
@@ -78,7 +78,7 @@ class FittingRunner:
                 # value and all upper values in separate arrays
 
                 # lbfgs uses gtol when using tol, so will do the same here
-                xbounds = np.array([np.array(elem) for elem in self._xbounds])
+                xbounds = np.array(self._xbounds)
                 self._sol = least_squares(
                     self._targfun,
                     self._x,
@@ -103,7 +103,7 @@ class FittingRunner:
             # As we are fitting, the config will only contain the results
             # prior to the applying results_function, so update the actual
             # values now
-            self._runner.config.results = self._runner._apply_results_function(
+            self._runner.config.results = self._runner.apply_results_function(
                 self._runner.config.results, dict(zip(self._xnames, self._sol["x"]))
             )
 
@@ -142,7 +142,7 @@ class FittingRunner:
         y = self._obtain_results(vardict)
 
         # Apply the results function
-        y = self._runner._apply_results_function(y, vardict)
+        y = self._runner.apply_results_function(y, vardict)
 
         if mpi.is_root:
             # Compare with target data

--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -117,6 +117,8 @@ class MuSpinInput:
             "method": None,
             "rtol": None,
             "function": None,
+            # When true indicates all fitting can be done after the simulation
+            "single_simulation": True,
         }
 
         if file_stream is not None:
@@ -172,6 +174,20 @@ class MuSpinInput:
 
                     if issubclass(KWClass, MuSpinEvaluateKeyword):
                         kw = KWClass(block, args=args, variables=self._variables)
+
+                        # In cases where fitting parameters are only used
+                        # as variables for 'results_function' and no where
+                        # else we only need to run the simulation once
+                        if self._fitting_info["single_simulation"]:
+                            for value in kw._values[0]:
+                                if name != "results_function":
+                                    if np.any(
+                                        np.in1d(
+                                            list(self._variables.keys()),
+                                            list(value._variables),
+                                        )
+                                    ):
+                                        self._fitting_info["single_simulation"] = False
                     else:
                         kw = KWClass(block, args=args)
 

--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -229,7 +229,10 @@ class MuSpinInput:
                 # Special case where we don't want to evaluate the expression
                 # yet
                 elif name in ["results_function"]:
-                    result[name] = self._keywords[name]
+                    if name in self._keywords:
+                        result[name] = self._keywords[name]
+                    elif KWClass.default is not None:
+                        result[name] = KWClass()
                 elif name in self._keywords:
                     kw = self._keywords[name]
                     v = variables if issubclass(KWClass, MuSpinEvaluateKeyword) else {}

--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -250,14 +250,9 @@ class MuSpinInput:
                 elif name in ["results_function"]:
                     if name in self._keywords:
                         result[name] = self._keywords[name]
-                    elif KWClass.default is not None:
-                        v = (
-                            variables
-                            if issubclass(KWClass, MuSpinEvaluateKeyword)
-                            else {}
-                        )
-
-                        result[name] = KWClass(variables=v)
+                    else:
+                        # Default
+                        result[name] = KWClass(variables=variables)
                 elif name in self._keywords:
                     kw = self._keywords[name]
                     v = variables if issubclass(KWClass, MuSpinEvaluateKeyword) else {}

--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -111,7 +111,13 @@ class MuSpinInput:
 
         self._keywords = {}
         self._variables = {}
-        self._fitting_info = {"fit": False, "data": None, "method": None, "rtol": None}
+        self._fitting_info = {
+            "fit": False,
+            "data": None,
+            "method": None,
+            "rtol": None,
+            "function": None,
+        }
 
         if file_stream is not None:
 
@@ -176,6 +182,7 @@ class MuSpinInput:
                         self._keywords[name][kwid] = kw
                     else:
                         self._keywords[name] = kw
+
                 except (ValueError, LarkExpressionError, RuntimeError) as exc:
                     errors_found += [
                         write_error(name, block_line_nums[header], str(exc))
@@ -219,6 +226,10 @@ class MuSpinInput:
                     "fitting_method",
                 ]:
                     pass
+                # Special case where we don't want to evaluate the expression
+                # yet
+                elif name in ["results_function"]:
+                    result[name] = self._keywords[name]
                 elif name in self._keywords:
                     kw = self._keywords[name]
                     v = variables if issubclass(KWClass, MuSpinEvaluateKeyword) else {}

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -6,6 +6,7 @@ Classes to define and read conveniently individual keywords of an input file
 import re
 import sys
 import inspect
+from typing import List
 import numpy as np
 
 from muspinsim.constants import MU_GAMMA
@@ -221,6 +222,10 @@ class MuSpinEvaluateKeyword(MuSpinKeyword):
     _functions = {**_math_functions}
     _constants = {**_math_constants}
 
+    # Special variables that should be accepted by the keyword, but do not
+    # automatically have values
+    _special_variables: List[str] = None
+
     def __init__(self, block=None, args=None, variables=None):
         # Fix W0102:dangerous-default-value
         if block is None:
@@ -231,6 +236,8 @@ class MuSpinEvaluateKeyword(MuSpinKeyword):
             variables = []
 
         cnames = set(self._constants.keys())
+        if self._special_variables:
+            cnames.update(set(self._special_variables))
         fnames = set(self._functions.keys())
         vnames = set(variables)
 
@@ -536,7 +543,7 @@ class KWFittingVariables(MuSpinKeyword):
 
     name = "fitting_variables"
     block_size = 1
-    expr_size_bounds = (1, 4)
+    expr_size_bounds = (1, np.inf)
     accept_range = True
     default = ""
     _constants = {**_math_constants, **_phys_constants}
@@ -608,6 +615,15 @@ class KWFittingTolerance(MuSpinKeyword):
         if not float(s[0])
         else "",
     ]
+
+
+class KWResultsFunction(MuSpinExpandKeyword):
+
+    name = "results_function"
+    block_size = 1
+    accept_range = False
+    default = "x"
+    _special_variables = ["x", "y"]
 
 
 # Special configuration keyword

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -608,7 +608,7 @@ class KWFittingMethod(MuSpinKeyword):
     default = "nelder-mead"
     _validators = [
         lambda s: (
-            f"Invalid value {s[0].lower()}, accepted values "
+            f"Invalid value '{s[0].lower()}', accepted values "
             f"{KWFittingMethod.ACCEPTED_FITTING_METHODS}"
         )
         if s[0].lower() not in KWFittingMethod.ACCEPTED_FITTING_METHODS

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -622,7 +622,7 @@ class KWResultsFunction(MuSpinExpandKeyword):
     name = "results_function"
     block_size = 1
     accept_range = False
-    default = "x"
+    default = "y"
     _special_variables = ["x", "y"]
 
 

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -600,15 +600,18 @@ class KWFittingData(MuSpinExpandKeyword):
 
 class KWFittingMethod(MuSpinKeyword):
 
+    ACCEPTED_FITTING_METHODS = ["nelder-mead", "lbfgs", "least-squares"]
+
     name = "fitting_method"
     block_size = 1
     accept_range = False
     default = "nelder-mead"
     _validators = [
         lambda s: (
-            f"Invalid value {s[0].lower()}, accepted values ['nelder-mead', 'lbfgs']"
+            f"Invalid value {s[0].lower()}, accepted values "
+            f"{KWFittingMethod.ACCEPTED_FITTING_METHODS}"
         )
-        if s[0].lower() not in ["nelder-mead", "lbfgs"]
+        if s[0].lower() not in KWFittingMethod.ACCEPTED_FITTING_METHODS
         else ""
     ]
 

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -632,6 +632,7 @@ class KWResultsFunction(MuSpinExpandKeyword):
     block_size = 1
     accept_range = False
     default = "y"
+    _constants = {**_math_constants, **_phys_constants}
     _special_variables = ["x", "y"]
 
 

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -236,10 +236,10 @@ class MuSpinEvaluateKeyword(MuSpinKeyword):
             variables = []
 
         cnames = set(self._constants.keys())
-        if self._special_variables:
-            cnames.update(set(self._special_variables))
         fnames = set(self._functions.keys())
         vnames = set(variables)
+        if self._special_variables:
+            vnames.update(set(self._special_variables))
 
         conflicts = cnames.intersection(vnames)
         conflicts = conflicts.union(fnames.intersection(vnames))

--- a/muspinsim/input/keyword.py
+++ b/muspinsim/input/keyword.py
@@ -37,6 +37,9 @@ _phys_constants = {"muon_gyr": MU_GAMMA, "MHz": 1.0 / (2 * MU_GAMMA)}
 
 _pwd_functions = {"zcw": zcw_gen, "eulrange": eulrange_gen}
 
+# Reserved variables that should not be allowed as fitting parameter names
+_reserved_variables = {"x", "y"}
+
 
 # Expansion functions
 def _range(x1, x2, n=100):
@@ -550,7 +553,13 @@ class KWFittingVariables(MuSpinKeyword):
     _validators = [
         lambda s: f"Invalid value '{s.name}': variable name conflicts with a constant"
         if s.name in {**_math_constants, **_phys_constants}
-        else ""
+        else "",
+        lambda s: (
+            f"Invalid value '{s.name}': variable name conflicts with a reserved "
+            "variable name"
+        )
+        if s.name in _reserved_variables
+        else "",
     ]
 
     def _store_values(self, block):

--- a/muspinsim/simconfig.py
+++ b/muspinsim/simconfig.py
@@ -180,6 +180,9 @@ class MuSpinConfig:
         if finfo["fit"]:
             if len(self._file_ranges) > 0:
                 raise MuSpinConfigError("Can not have file ranges when fitting")
+            logging.warning(
+                "'x_axis' values will be overwritten by the experimental data"
+            )
             # The x axis is overridden, whatever it is
             xname = list(self._x_range.keys())[0]
             self._constants.pop(xname, None)  # Just in case it was here

--- a/muspinsim/simconfig.py
+++ b/muspinsim/simconfig.py
@@ -104,6 +104,7 @@ class MuSpinConfig:
         self._spins = self.validate("spins", params["spins"].value[0])
         self._celio = self._validate_celio(params["celio"].value[0])
         self._y_axis = self.validate("y", params["y_axis"].value[0])[0]
+        self._results_function = params["results_function"]
 
         # Identify ranges
         try:
@@ -441,6 +442,10 @@ Parameters used:
     @property
     def y_axis(self):
         return self._y_axis
+
+    @property
+    def results_function(self):
+        return self._results_function
 
     def __len__(self):
         return len(self._configurations)

--- a/muspinsim/tests/test_celio.py
+++ b/muspinsim/tests/test_celio.py
@@ -7,7 +7,7 @@ from muspinsim.spinop import DensityOperator
 from muspinsim.spinsys import MuonSpinSystem, SingleTerm, SpinSystem
 
 
-class TestCelioHamilto(unittest.TestCase):
+class TestCelioHamiltonian(unittest.TestCase):
     def test_sum(self):
         ssys = SpinSystem(["mu", "e"], celio_k=10)
         ssys.add_linear_term(0, [1, 0, 0])  # Precession around x

--- a/muspinsim/tests/test_celio.py
+++ b/muspinsim/tests/test_celio.py
@@ -126,7 +126,7 @@ class TestCelioHamilto(unittest.TestCase):
 
         self.assertTrue(isinstance(H, CelioHamiltonian))
 
-        evol = H.evolve(rho0, t, ssys.operator({0: "z"}))
+        evol = H.evolve(rho0, t, [ssys.operator({0: "z"})])
 
         self.assertTrue(np.all(np.isclose(evol[:, 0], 0.5 * np.cos(2 * np.pi * t))))
 

--- a/muspinsim/tests/test_config.py
+++ b/muspinsim/tests/test_config.py
@@ -292,7 +292,7 @@ orientation
         stest = StringIO(
             """
 fitting_variables
-    x
+    A
 fitting_data
     0   0.5
     1   0.2
@@ -300,7 +300,7 @@ fitting_data
         )
 
         itest = MuSpinInput(stest)
-        cfg = MuSpinConfig(itest.evaluate(x=0.0))
+        cfg = MuSpinConfig(itest.evaluate(A=0.0))
         # Check that the time axis has been overridden
         self.assertTrue((np.array(cfg._x_range["t"]) == [0, 1]).all())
 
@@ -308,7 +308,7 @@ fitting_data
         stest = StringIO(
             """
 fitting_variables
-    x
+    A
 fitting_data
     0   0.5
     1   0.2
@@ -322,4 +322,4 @@ orientation
 
         itest = MuSpinInput(stest)
         with self.assertRaises(MuSpinConfigError):
-            cfg = MuSpinConfig(itest.evaluate(x=0.0))
+            cfg = MuSpinConfig(itest.evaluate(A=0.0))

--- a/muspinsim/tests/test_config.py
+++ b/muspinsim/tests/test_config.py
@@ -81,6 +81,11 @@ dissipation 2
         self.assertIn("t", cfg._x_range)
         self.assertIn("orient", cfg._avg_ranges)
 
+        array = np.arange(0, 5)
+        np.testing.assert_allclose(
+            cfg.results_function.evaluate(x=array * 2, y=array)[0], array
+        )
+
         # Now try a few errors
 
         stest = StringIO(

--- a/muspinsim/tests/test_experiment.py
+++ b/muspinsim/tests/test_experiment.py
@@ -246,7 +246,8 @@ results_function
         self.assertTrue(np.all(np.isclose(results, np.cos(2 * np.pi * times) / np.e)))
 
         # Results function is expected to be ignored by experiment when
-        # fitting variables are introduced
+        # fitting variables are introduced (as it would be applied by
+        # FittingRunner in normal, command-line usage)
         stest = StringIO(
             """
 spins

--- a/muspinsim/tests/test_fitting.py
+++ b/muspinsim/tests/test_fitting.py
@@ -58,6 +58,54 @@ dissipation 1
 
         self.assertAlmostEqual(sol.x[0], g, 3)
 
+        # Try fitting a very basic exponential decay
+        # with lbfgs
+        s1 = StringIO(
+            f"""
+spins
+    mu
+fitting_method
+    lbfgs
+fitting_variables
+    g   0.5
+fitting_data
+{dblock}
+dissipation 1
+    g
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+
+        sol = f1.run()
+
+        self.assertAlmostEqual(sol.x[0], g, 3)
+
+        # Try fitting a very basic exponential decay
+        # with least_squares
+        s1 = StringIO(
+            f"""
+spins
+    mu
+fitting_method
+    least-squares
+fitting_variables
+    g   0.5
+fitting_data
+{dblock}
+dissipation 1
+    g
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+
+        sol = f1.run()
+
+        self.assertAlmostEqual(sol.x[0], g, 2)
+
     def test_fit_results_function(self):
 
         # Try fitting a basic cosine function
@@ -88,3 +136,53 @@ fitting_data
 
         self.assertAlmostEqual(sol.x[0], A, 3)
         self.assertAlmostEqual(sol.x[1], B, 3)
+
+        # Try fitting a basic cosine with lbfgs
+        s1 = StringIO(
+            f"""
+spins
+    mu
+results_function
+    A*cos(x)+B
+fitting_method
+    lbfgs
+fitting_variables
+    A 0.5
+    B 0.5
+fitting_data
+{dblock}
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+
+        sol = f1.run()
+
+        self.assertAlmostEqual(sol.x[0], A, 1)
+        self.assertAlmostEqual(sol.x[1], B, 1)
+
+        # Try fitting a basic cosine with least_squares
+        s1 = StringIO(
+            f"""
+spins
+    mu
+results_function
+    A*cos(x)+B
+fitting_method
+    least-squares
+fitting_variables
+    A 0.5
+    B 0.5
+fitting_data
+{dblock}
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+
+        sol = f1.run()
+
+        self.assertAlmostEqual(sol.x[0], A, 2)
+        self.assertAlmostEqual(sol.x[1], B, 2)

--- a/muspinsim/tests/test_fitting.py
+++ b/muspinsim/tests/test_fitting.py
@@ -12,8 +12,8 @@ class TestFitting(unittest.TestCase):
         s1 = StringIO(
             """
 fitting_variables
-    x  0.0
-    y  1.0 0 2.0
+    A  0.0
+    B  1.0 0 2.0
 fitting_data
     0   0.5
     1   0.5
@@ -24,7 +24,7 @@ fitting_data
         i1 = MuSpinInput(s1)
         f1 = FittingRunner(i1)
 
-        self.assertEqual(f1._xnames, ("x", "y"))
+        self.assertEqual(f1._xnames, ("A", "B"))
         self.assertTrue((f1._x == [0, 1]).all())
         self.assertEqual(f1._xbounds[0], (-np.inf, np.inf))
         self.assertEqual(f1._xbounds[1], (0.0, 2.0))

--- a/muspinsim/tests/test_fitting.py
+++ b/muspinsim/tests/test_fitting.py
@@ -39,18 +39,16 @@ fitting_data
         dblock = "\n".join(["\t{0} {1}".format(*d) for d in data])
 
         s1 = StringIO(
-            """
+            f"""
 spins
     mu
 fitting_variables
     g   0.5
 fitting_data
-{data}
+{dblock}
 dissipation 1
     g
-""".format(
-                data=dblock
-            )
+"""
         )
 
         i1 = MuSpinInput(s1)
@@ -59,3 +57,34 @@ dissipation 1
         sol = f1.run()
 
         self.assertAlmostEqual(sol.x[0], g, 3)
+
+    def test_fit_results_function(self):
+
+        # Try fitting a basic cosine function
+        A = 2
+        B = 1
+        x_values = np.arange(0, 10)
+        y_values = A * np.cos(x_values) + B
+        dblock = "\n".join(["\t{0} {1}".format(*d) for d in zip(x_values, y_values)])
+
+        s1 = StringIO(
+            f"""
+spins
+    mu
+results_function
+    A*cos(x)+B
+fitting_variables
+    A 0.5
+    B 0.5
+fitting_data
+{dblock}
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+
+        sol = f1.run()
+
+        self.assertAlmostEqual(sol.x[0], A, 3)
+        self.assertAlmostEqual(sol.x[1], B, 3)

--- a/muspinsim/tests/test_input.py
+++ b/muspinsim/tests/test_input.py
@@ -579,7 +579,7 @@ zeeman 1
     def test_input_fitting_results_function(self):
         # Test input focused around fitting 'results_function'
 
-        # Should detect only need a single simulation
+        # Should detect we only need a single simulation
         i1 = MuSpinInput(
             StringIO(
                 """
@@ -615,7 +615,7 @@ results_function
         self.assertEqual(variables["A"].bounds, (0.0, 2.0))
         self.assertTrue(i1.fitting_info["single_simulation"])
 
-        # Should detect need multiple simulations
+        # Should detect the need for multiple simulations
         i1 = MuSpinInput(
             StringIO(
                 """
@@ -650,6 +650,28 @@ results_function
         self.assertEqual(variables["A"].value, 1.0)
         self.assertEqual(variables["A"].bounds, (0.0, 2.0))
         self.assertFalse(i1.fitting_info["single_simulation"])
+
+        # Should detect we only need a single simulation
+        i1 = MuSpinInput(
+            StringIO(
+                """
+fitting_variables
+    A 1.0 0.0 2.0
+fitting_data
+    0  0.0
+    1  1.0
+    2  4.0
+    3  9.0
+field
+    2/muon_gyr
+zeeman 1
+    1 1 0
+results_function
+    2*A
+"""
+            )
+        )
+        self.assertTrue(i1.fitting_info["single_simulation"])
 
     def _write_temp_file(self, tdata):
         tfile = NamedTemporaryFile(mode="w", delete=False)

--- a/muspinsim/tests/test_input.py
+++ b/muspinsim/tests/test_input.py
@@ -4,6 +4,7 @@ from io import StringIO
 from tempfile import NamedTemporaryFile
 
 from muspinsim.input.keyword import (
+    KWFittingMethod,
     MuSpinKeyword,
     MuSpinEvaluateKeyword,
     MuSpinExpandKeyword,
@@ -183,6 +184,30 @@ class TestInput(unittest.TestCase):
             }
         )
 
+    def test_keyword_intrinsic_field_range(self):
+        self._eval_kw(
+            {
+                "kw": "intrinsic_field",
+                "args": [],
+                "in": ["range(0, 20, 21)"],
+                "out": np.arange(21)[:, None],
+            }
+        )
+
+    def test_keyword_intrinsic_field_mhz(self):
+        kw = InputKeywords["intrinsic_field"](["500*MHz"])
+        self.assertTrue(np.isclose(kw.evaluate()[0][0], 1.84449016))
+
+    def test_keyword_intrinsic_field_defaults(self):
+        self._eval_kw(
+            {
+                "kw": "intrinsic_field",
+                "args": [],
+                "in": [],
+                "out": np.array([0]),
+            }
+        )
+
     def test_keyword_time_defaults(self):
         self._eval_kw(
             {
@@ -333,6 +358,87 @@ class TestInput(unittest.TestCase):
                 "in": [],
                 "out": np.array([0, 0, 0]),
             }
+        )
+
+    def test_keyword_fitting_method(self):
+        self._eval_kw(
+            {
+                "kw": "fitting_method",
+                "args": [],
+                "in": ["nelder-mead"],
+                "out": np.array(["nelder-mead"]),
+            }
+        )
+
+        self._eval_kw(
+            {
+                "kw": "fitting_method",
+                "args": [],
+                "in": ["lbfgs"],
+                "out": np.array(["lbfgs"]),
+            }
+        )
+
+        self._eval_kw(
+            {
+                "kw": "fitting_method",
+                "args": [],
+                "in": ["least-squares"],
+                "out": np.array(["least-squares"]),
+            }
+        )
+
+    def test_keyword_fitting_method_invalid(self):
+        with self.assertRaises(ValueError) as err:
+            InputKeywords["fitting_method"](
+                ["something"], args=[]
+            )  # Invalid value for argument
+        self.assertEqual(
+            str(err.exception),
+            (
+                "Invalid value 'something', accepted values "
+                f"{KWFittingMethod.ACCEPTED_FITTING_METHODS}"
+            ),
+        )
+
+    def test_keyword_celio(self):
+        self._eval_kw(
+            {
+                "kw": "celio",
+                "args": [],
+                "in": ["1"],
+                "out": np.array(["1"]),
+            }
+        )
+
+        self._eval_kw(
+            {
+                "kw": "celio",
+                "args": [],
+                "in": ["1 2"],
+                "out": np.array(["1", "2"]),
+            }
+        )
+
+    def test_keyword_celio_defaults(self):
+        self._eval_kw(
+            {
+                "kw": "celio",
+                "args": [],
+                "in": [],
+                "out": np.array(["0", "0"]),
+            }
+        )
+
+    def test_keyword_celio_invalid(self):
+        with self.assertRaises(RuntimeError) as err:
+            InputKeywords["celio"](["1 2 3"], args=[])  # Invalid value for argument
+        self.assertEqual(
+            str(err.exception),
+            (
+                "Incorrect number of args for entry '1 2 3', "
+                "expected between 1 and 2, got 3"
+            ),
         )
 
     def test_input_valid(self):

--- a/muspinsim/tests/test_input.py
+++ b/muspinsim/tests/test_input.py
@@ -546,16 +546,16 @@ results_function
             StringIO(
                 """
 fitting_variables
-    x 1.0 0.0 2.0
+    A 1.0 0.0 2.0
 fitting_data
     0  0.0
     1  1.0
     2  4.0
     3  9.0
 field
-    2*x
+    2*A
 zeeman 1
-    x x 0
+    A A 0
 """
             )
         )
@@ -565,14 +565,14 @@ zeeman 1
         data = i1.fitting_info["data"]
         self.assertTrue((data == [[0, 0], [1, 1], [2, 4], [3, 9]]).all())
 
-        e1 = i1.evaluate(x=2.0)
+        e1 = i1.evaluate(A=2.0)
         self.assertEqual(e1["field"].value[0][0], 4.0)
         self.assertTrue((e1["couplings"]["zeeman_1"].value[0] == [2, 2, 0]).all())
 
         variables = i1.variables
 
-        self.assertEqual(variables["x"].value, 1.0)
-        self.assertEqual(variables["x"].bounds, (0.0, 2.0))
+        self.assertEqual(variables["A"].value, 1.0)
+        self.assertEqual(variables["A"].bounds, (0.0, 2.0))
 
         self.assertFalse(i1.fitting_info["single_simulation"])
 
@@ -693,7 +693,7 @@ results_function
             StringIO(
                 """
 fitting_variables
-    x
+    A
 fitting_data
     load("{fname}")
 fitting_method
@@ -719,7 +719,7 @@ fitting_method
                 StringIO(
                     """
 fitting_variables
-    x 1.0 0.0 5.0
+    A 1.0 0.0 5.0
 """
                 )
             )
@@ -742,24 +742,24 @@ fitting_variables
                 StringIO(
                     """
 fitting_variables
-    x 1.0 0.0 -5.0
+    A 1.0 0.0 -5.0
 fitting_data
     load("{fname}")
 fitting_method
     nelder-mead
 field
-    2*x
+    2*A
 zeeman 1
-    x x 0
+    A A 0
 """.format(
                         fname=tfile.name
                     )
                 )
             )
         self.assertTrue(
-            "Variable x has invalid range: "
+            "Variable A has invalid range: "
             "(max value -5.0 cannot be less than or equal to min value 0.0)\n"
-            "Variable x has invalid starting value: "
+            "Variable A has invalid starting value: "
             "(starting value 1.0 cannot be greater than max value -5.0)"
             in str(err.exception)
         )
@@ -778,7 +778,7 @@ fitting_data
     2  4.0
     3  9.0
 field
-    2*x
+    2*A
 zeeman 1
     MHz 0 0
 """
@@ -790,4 +790,57 @@ zeeman 1
             "Error occurred when parsing keyword 'fitting_variables' "
             "(block starting at line 2):\n"
             "Invalid value 'MHz': variable name conflicts with a constant",
+        )
+
+        # variable name clashes with reserved variables
+        with self.assertRaises(MuSpinInputError) as err:
+            MuSpinInput(
+                StringIO(
+                    """
+fitting_variables
+    x 1.0 0.0 5.0
+fitting_data
+    0  0.0
+    1  1.0
+    2  4.0
+    3  9.0
+field
+    2*x
+zeeman 1
+    MHz 0 0
+"""
+                )
+            )
+        self.assertEqual(
+            str(err.exception),
+            "Found 1 Error(s) whilst trying to parse fitting keywords: \n\n"
+            "Error occurred when parsing keyword 'fitting_variables' "
+            "(block starting at line 2):\n"
+            "Invalid value 'x': variable name conflicts with a reserved variable name",
+        )
+
+        with self.assertRaises(MuSpinInputError) as err:
+            MuSpinInput(
+                StringIO(
+                    """
+fitting_variables
+    y 1.0 0.0 5.0
+fitting_data
+    0  0.0
+    1  1.0
+    2  4.0
+    3  9.0
+field
+    2*y
+zeeman 1
+    MHz 0 0
+"""
+                )
+            )
+        self.assertEqual(
+            str(err.exception),
+            "Found 1 Error(s) whilst trying to parse fitting keywords: \n\n"
+            "Error occurred when parsing keyword 'fitting_variables' "
+            "(block starting at line 2):\n"
+            "Invalid value 'y': variable name conflicts with a reserved variable name",
         )

--- a/muspinsim/tests/test_validation.py
+++ b/muspinsim/tests/test_validation.py
@@ -2,8 +2,10 @@ import unittest
 
 import numpy as np
 from muspinsim.spinop import DensityOperator, SpinOperator
+from muspinsim.spinsys import InteractionTerm, MuonSpinSystem
 
 from muspinsim.validation import (
+    validate_celio_params,
     validate_evolve_params,
     validate_integrate_decaying_params,
     validate_times,
@@ -46,6 +48,20 @@ class TestValidation(unittest.TestCase):
                 np.array([0, 1]),
                 [SpinOperator.from_axes(), 2],
             )
+
+    def test_validate_celio(self):
+        # Should work
+        spin_system = MuonSpinSystem(["e", "mu"])
+        interaction_terms = [InteractionTerm(spin_system)]
+        validate_celio_params(interaction_terms, np.array([0, 1, 2]))
+
+        # No terms
+        with self.assertRaises(ValueError):
+            validate_celio_params([], np.array([0, 1, 2]))
+
+        # Invalid initial time
+        with self.assertRaises(ValueError):
+            validate_celio_params(interaction_terms, np.array([1, 2, 3]))
 
     def test_validate_integrate_decaying_params(self):
         # Should work

--- a/muspinsim/tests/test_validation.py
+++ b/muspinsim/tests/test_validation.py
@@ -63,6 +63,10 @@ class TestValidation(unittest.TestCase):
         with self.assertRaises(ValueError):
             validate_celio_params(interaction_terms, np.array([1, 2, 3]))
 
+        # Uneven spacing between times
+        with self.assertRaises(ValueError):
+            validate_celio_params(interaction_terms, np.array([0, 1, 2.5, 3]))
+
     def test_validate_integrate_decaying_params(self):
         # Should work
         validate_integrate_decaying_params(

--- a/muspinsim/validation.py
+++ b/muspinsim/validation.py
@@ -45,6 +45,26 @@ def validate_evolve_params(rho0, times, operators):
         )
 
 
+def validate_celio_params(terms, times):
+    """Validates the required parameters for any method using Celio's
+
+    Arguments:
+        terms {[InteractionTerm]} -- Interaction terms that will form part of the
+                                     Trotter expansion
+        times {ndarray} -- Times to compute the evolution for, in microseconds
+
+    Raises:
+        ValueError -- If there are no terms to evolve with
+        ValueError -- If the first time does not start at 0
+    """
+
+    if len(terms) == 0:
+        raise ValueError("No interaction terms to evolve")
+
+    if times[0] != 0:
+        raise ValueError("Cannot use Celio's method with a non-zero start time")
+
+
 def validate_integrate_decaying_params(rho0, tau, operators):
     """Validates the required parameters for 'integrate_decaying' methods
        in the Hamiltonian and Linbladian classes

--- a/muspinsim/validation.py
+++ b/muspinsim/validation.py
@@ -56,6 +56,7 @@ def validate_celio_params(terms, times):
     Raises:
         ValueError -- If there are no terms to evolve with
         ValueError -- If the first time does not start at 0
+        ValueError -- If the times have uneven spacing
     """
 
     if len(terms) == 0:
@@ -63,6 +64,11 @@ def validate_celio_params(terms, times):
 
     if times[0] != 0:
         raise ValueError("Cannot use Celio's method with a non-zero start time")
+
+    # Ensure the spacing is identical between all the values
+    differences = np.diff(times)
+    if not np.isclose(differences, differences[0]).all():
+        raise ValueError("Cannot use Celio's method with uneven spacing between times")
 
 
 def validate_integrate_decaying_params(rho0, tau, operators):


### PR DESCRIPTION
Adds a parameter `results_function` that can take all the usual constants, variables and functions available to the input file and additionally two extra 'x' and 'y' representing the output of muspinsim's simulation and runs it before outputting the results. This allows fitting on functions that modify the data e.g.
```
results_function
    A*y+B
```
For a linear fit, offsetting the y values and scaling them.

This also detects when fitting parameters are present in any sections of the input other than this function, and in the case they are only used in `results_function` the FittingRunner will cache the results and only run the simulation once, but repeatedly fit with this function so that it can run significantly faster for large systems.

### Other notes
- Also adds `least-squares` as an additional fitting method (it behaves better than the default nelder-mead in the case of linear fitting but it also typically requires more function evaluations so is not as suitable for atomistic fitting)
    - It seems nelder-mead is just more prone to getting stuck looking at the solution here: https://stackoverflow.com/questions/72152400/nelder-mead-isnt-converging-scipy-why-is-there-only-one-initial-point 
- Includes docs for these changes
- Fixes bug preventing fitting with OpenMPI using `mpirun -n`
- Removes a limit of a maximum of 4 fitting variables

Closes #77