### PR TITLE
Some sparse matrix usage improvements

### DIFF
--- a/muspinsim/celio.py
+++ b/muspinsim/celio.py
@@ -205,7 +205,7 @@ class CelioHamiltonian:
 
         return evol_op_contribs
 
-    def evolve(self, rho0, times, operators=None):
+    def evolve(self, rho0, times, operators):
         """Time evolution of a state under this Hamiltonian
 
         Perform an evolution of a state described by a DensityOperator under
@@ -219,24 +219,22 @@ class CelioHamiltonian:
         Keyword Arguments:
             operators {[SpinOperator]} -- List of SpinOperators to compute the
                                           expectation values of at each step.
-                                          If omitted, the states' density
-                                          matrices will be returned instead
-                                           (default: {[]})
 
         Returns:
-            [DensityOperator | ndarray] -- DensityOperators or expectation values
+            [ndarray] -- Expectation values
 
         Raises:
             TypeError -- Invalid operators
             ValueError -- Invalid values of times or operators
             RuntimeError -- Hamiltonian is not hermitian
         """
-        if operators is None:
-            operators = []
 
         times = np.array(times)
         if isinstance(operators, SpinOperator):
             operators = [operators]
+
+        if not operators:
+            raise ValueError("At least one SpinOperator must be present in 'operators'")
 
         validate_evolve_params(rho0, times, operators)
 
@@ -481,7 +479,7 @@ class CelioHamiltonian:
         # 0.5 and -0.5
         return results * avg_factor * 0.5
 
-    def integrate_decaying(self, rho0, tau, operators=None):
+    def integrate_decaying(self, rho0, tau, operators):
         """Called to integrate one or more expectation values in time with decay
 
         Raises:

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -179,14 +179,16 @@ class ExperimentRunner:
                     r = DensityOperator.from_vectors(I, muon_axis, 0)
                 else:
                     # Get the Zeeman Hamiltonian for this field
+                    # Don't bother using sparse, we need them dense for eigh
+                    # anyway
                     Hz = np.sum(
                         [
-                            B[j] * SpinOperator.from_axes(I, e).matrix
+                            B[j] * SpinOperator.from_axes(I, e, use_sparse=False).matrix
                             for j, e in enumerate("xyz")
                         ],
                         axis=0,
                     )
-                    evals, evecs = np.linalg.eigh(Hz.toarray())
+                    evals, evecs = np.linalg.eigh(Hz)
                     E = evals * 1e6 * self._system.gamma(i)
 
                     if T > 0:

--- a/muspinsim/hamiltonian.py
+++ b/muspinsim/hamiltonian.py
@@ -76,12 +76,10 @@ class Hamiltonian(Operator, Hermitian):
 
         # Turn the density matrix in the right basis
         dim = rho0.dimension
-        rho0 = rho0.basis_change(evecs).matrix.toarray()
+        rho0 = rho0.basis_change(evecs).matrix
 
         # Same for operators
-        operatorsT = np.array(
-            [o.basis_change(evecs).matrix.T.toarray() for o in operators]
-        )
+        operatorsT = np.array([o.basis_change(evecs).matrix.T for o in operators])
 
         # Matrix of evolution operators
         ll = -2.0j * np.pi * (evals[:, None] - evals[None, :])
@@ -151,16 +149,13 @@ class Hamiltonian(Operator, Hermitian):
         evals, evecs = self.diag()
 
         # Turn the density matrix in the right basis
-        rho0 = rho0.basis_change(evecs).matrix.toarray()
+        rho0 = rho0.basis_change(evecs).matrix
 
         ll = 2.0j * np.pi * (evals[:, None] - evals[None, :])
 
         # Integral operators
         intops = np.array(
-            [
-                (-o.basis_change(evecs).matrix.toarray() / (ll - 1.0 / tau)).T
-                for o in operators
-            ]
+            [(-o.basis_change(evecs).matrix / (ll - 1.0 / tau)).T for o in operators]
         )
 
         result = np.sum(rho0[None, :, :] * intops[:, :, :], axis=(1, 2))

--- a/muspinsim/hamiltonian.py
+++ b/muspinsim/hamiltonian.py
@@ -116,7 +116,7 @@ class Hamiltonian(Operator, Hermitian):
             ]
         return result
 
-    def integrate_decaying(self, rho0, tau, operators=None):
+    def integrate_decaying(self, rho0, tau, operators):
         """Integrate one or more expectation values in time with decay
 
         Perform an integral in time from 0 to +inf of an expectation value
@@ -130,7 +130,7 @@ class Hamiltonian(Operator, Hermitian):
 
         Keyword Arguments:
             operators {list} -- Operators to compute the expectation values
-                                of (default: {[]})
+                                of
 
         Returns:
             ndarray -- List of integral values
@@ -140,8 +140,6 @@ class Hamiltonian(Operator, Hermitian):
             ValueError -- Invalid values of tau or operators
             RuntimeError -- Hamiltonian is not hermitian
         """
-        if operators is None:
-            operators = []
 
         if isinstance(operators, SpinOperator):
             operators = [operators]

--- a/muspinsim/hamiltonian.py
+++ b/muspinsim/hamiltonian.py
@@ -107,12 +107,13 @@ class Hamiltonian(Operator, Hermitian):
                     result = np.concatenate(([result, single_res]), axis=0)
         else:
             sceve = evecs.T.conj()
-            for i in range(times.shape[0]):
-                # Just return density matrices
-                result = [
-                    DensityOperator(calc_single_rho(i), dim).basis_change(sceve)
-                    for i in range(times.shape[0])
-                ]
+            # Just return density matrices
+            result = [
+                DensityOperator(calc_single_rho(i)[0], dim).basis_change(
+                    sceve, use_sparse=True
+                )
+                for i in range(times.shape[0])
+            ]
         return result
 
     def integrate_decaying(self, rho0, tau, operators=None):

--- a/muspinsim/hamiltonian.py
+++ b/muspinsim/hamiltonian.py
@@ -17,19 +17,21 @@ from muspinsim.validation import (
 
 
 class Hamiltonian(Operator, Hermitian):
-    def __init__(self, matrix, dim=None):
+    def __init__(self, matrix, dim=None, use_sparse=True):
         """Create an Hamiltonian
 
         Create an Hamiltonian from a hermitian complex matrix
 
         Arguments:
             matrix {ndarray} -- Matrix representation of the Hamiltonian
+            dim {(int,...)} -- See Operator
+            use_sparse {bool} -- See Operator
 
         Raises:
             ValueError -- Matrix isn't square or hermitian
         """
 
-        super(Hamiltonian, self).__init__(matrix, dim)
+        super(Hamiltonian, self).__init__(matrix, dim, use_sparse=use_sparse)
 
     @classmethod
     def from_spin_operator(self, spinop):

--- a/muspinsim/lindbladian.py
+++ b/muspinsim/lindbladian.py
@@ -112,7 +112,7 @@ class Lindbladian(SuperOperator):
 
         return result
 
-    def integrate_decaying(self, rho0, tau, operators=None):
+    def integrate_decaying(self, rho0, tau, operators):
         """Integrate one or more expectation values in time with decay
 
         Perform an integral in time from 0 to +inf of an expectation value
@@ -126,7 +126,7 @@ class Lindbladian(SuperOperator):
 
         Keyword Arguments:
             operators {list} -- Operators to compute the expectation values
-                                of (default: {[]})
+                                of
 
         Returns:
             ndarray -- List of integral values
@@ -136,8 +136,6 @@ class Lindbladian(SuperOperator):
             ValueError -- Invalid values of tau or operators
             RuntimeError -- Hamiltonian is not hermitian
         """
-        if operators is None:
-            operators = []
 
         if isinstance(operators, SpinOperator):
             operators = [operators]

--- a/muspinsim/spinop.py
+++ b/muspinsim/spinop.py
@@ -152,6 +152,10 @@ class Operator(Clonable):
         y = self._matrix
         return np.abs(y - x).max() < self._htol
 
+    @property
+    def is_sparse(self):
+        return self._sparse
+
     def dagger(self):
         """Return the transpose conjugate of this Operator
 
@@ -337,7 +341,7 @@ class Operator(Clonable):
 
         return A.conjugate().T.dot(B).trace().item()
 
-    def basis_change(self, basis):
+    def basis_change(self, basis, use_sparse=False):
         """Return a version of this Operator with different basis
 
         Transform this Operator to use a different basis. The basis
@@ -346,14 +350,21 @@ class Operator(Clonable):
 
         Arguments:
             basis {ndarray} -- Basis to transform the operator to.
+            use_sparse -- Whether the computed matrix will be converted to
+                          a sparse format or not.
 
         Returns:
-            Operator -- Basis transformed version of this operator
+            Operator -- Basis transformed version of this operator (Note:
+                        this operator will then be dense unless
+                        use_sparse=True)
         """
 
         ans = self.clone()
         x = basis.T.conjugate()
         ans._matrix = x @ ans._matrix @ basis
+        if use_sparse:
+            ans._matrix = sparse.csr_matrix(ans._matrix)
+        ans._sparse = use_sparse
 
         return ans
 

--- a/muspinsim/spinop.py
+++ b/muspinsim/spinop.py
@@ -85,7 +85,7 @@ class Hermitian:
 
 
 class Operator(Clonable):
-    def __init__(self, matrix, dim=None, herm_tol=1e-6):
+    def __init__(self, matrix, dim=None, herm_tol=1e-6, use_sparse=True):
         """Create a Operator object
 
         Create an object representing a spin operator. These can
@@ -103,12 +103,18 @@ class Operator(Clonable):
                                the matrix (default: {None})
             herm_tol {float} -- Tolerance used to check for hermitianity of the
                                matrix (default: {1e-6})
+            use_sparse {bool} -- Determines whether to use sparse matrices for
+                                 storing this operator's matrix
 
         Raises:
             ValueError -- Any of the passed values are invalid
         """
-        # use sparse matrices
-        self._matrix = sparse.csr_matrix(matrix)
+        self._sparse = use_sparse
+
+        if self._sparse:
+            self._matrix = sparse.csr_matrix(matrix)
+        else:
+            self._matrix = np.array(matrix)
 
         if not matrix.shape[0] == matrix.shape[1]:
             raise ValueError("Matrix passed to Operator must be square")
@@ -159,6 +165,7 @@ class Operator(Clonable):
         ans = MyClass.__new__(MyClass)
         ans._dim = tuple(self._dim)
         ans._matrix = self.matrix.conjugate().T
+        ans._sparse = self._sparse
 
         return ans
 
@@ -179,7 +186,10 @@ class Operator(Clonable):
         elif isinstance(x, Number):
 
             ans = self.clone()
-            ans._matrix += sparse.eye(ans._matrix.shape[0]) * x
+            if self._sparse:
+                ans._matrix += sparse.eye(ans._matrix.shape[0]) * x
+            else:
+                ans._matrix += np.eye(ans._matrix.shape[0]) * x
 
             return ans
 
@@ -215,14 +225,22 @@ class Operator(Clonable):
                 )
 
             ans = self.clone()
-            ans._matrix = ans._matrix.dot(x._matrix)
+
+            if self._sparse:
+                ans._matrix = ans._matrix.dot(x._matrix)
+            else:
+                ans._matrix = ans._matrix @ x._matrix
 
             return ans
 
         elif isinstance(x, Number):
 
             ans = self.clone()
-            ans._matrix = ans._matrix.multiply(x)
+
+            if self._sparse:
+                ans._matrix = ans._matrix.multiply(x)
+            else:
+                ans._matrix *= x
 
             return ans
 
@@ -277,7 +295,12 @@ class Operator(Clonable):
         # Doing it this way saves some time
         ans = self.__class__.__new__(self.__class__)
         ans._dim = self._dim + x._dim
-        ans._matrix = sparse.kron(self._matrix, x._matrix, format="csr")
+        ans._sparse = self._sparse
+
+        if self._sparse:
+            ans._matrix = sparse.kron(self._matrix, x._matrix, format="csr")
+        else:
+            ans._matrix = np.kron(self._matrix, x._matrix)
 
         return ans
 
@@ -337,7 +360,7 @@ class Operator(Clonable):
 
 class SpinOperator(Operator):
     @classmethod
-    def from_axes(self, Is=0.5, axes="x"):
+    def from_axes(self, Is=0.5, axes="x", use_sparse=True):
         """Construct a SpinOperator from spins and axes
 
         Construct a SpinOperator from a list of spin values and directions. For
@@ -350,6 +373,8 @@ class SpinOperator(Operator):
             axes {[str]} -- List of axes, can pass a single character if it's
                             only one value. Each value can be x, y, z, +, -,
                             or 0 (for the identity operator) (default: {'x'})
+            use_sparse {bool} -- Whether to use a sparse matrix for storing the
+                                 generated operator's matrix
 
         Returns:
             SpinOperator -- Operator built according to specifications
@@ -387,11 +412,11 @@ class SpinOperator(Operator):
         for m in matrices[1:]:
             M = np.kron(M, m)
 
-        return self(sparse.csr_matrix(M), dim=dim)
+        return self(M, dim=dim, use_sparse=use_sparse)
 
 
 class DensityOperator(Operator):
-    def __init__(self, matrix, dim=None):
+    def __init__(self, matrix, dim=None, use_sparse=True):
         """Create a DensityOperator object
 
         Create an object representing a density operator. These can
@@ -412,7 +437,7 @@ class DensityOperator(Operator):
         Raises:
             ValueError -- Any of the passed values are invalid
         """
-        super(DensityOperator, self).__init__(matrix, dim)
+        super(DensityOperator, self).__init__(matrix, dim, use_sparse=use_sparse)
         # Enforce unitarity
 
         tr = self._matrix.trace()
@@ -499,7 +524,7 @@ class DensityOperator(Operator):
         for m in matrices[1:]:
             M = np.kron(M, m)
 
-        return self(sparse.csr_matrix(M), dim=dim)
+        return self(M, dim=dim)
 
     @property
     def trace(self):

--- a/muspinsim/spinop.py
+++ b/muspinsim/spinop.py
@@ -329,9 +329,8 @@ class Operator(Clonable):
         """
 
         ans = self.clone()
-        basis = sparse.csr_matrix(basis)
         x = basis.T.conjugate()
-        ans._matrix = x.dot(ans._matrix).dot(basis)
+        ans._matrix = x @ ans._matrix @ basis
 
         return ans
 

--- a/muspinsim/tests/test_celio.py
+++ b/muspinsim/tests/test_celio.py
@@ -130,6 +130,17 @@ class TestCelioHamilto(unittest.TestCase):
 
         self.assertTrue(np.all(np.isclose(evol[:, 0], 0.5 * np.cos(2 * np.pi * t))))
 
+    def test_evolve_invalid(self):
+        ssys = SpinSystem(["e"], celio_k=10)
+        ssys.add_linear_term(0, [1, 0, 0])  # Precession around x
+        H = ssys.hamiltonian
+        rho0 = DensityOperator.from_vectors()  # Start along z
+        t = np.linspace(0, 1, 100)
+
+        # No SpinOperator
+        with self.assertRaises(ValueError):
+            H.evolve(rho0, t, [])
+
     def test_fast_evolve(self):
         ssys = MuonSpinSystem(["mu", "e"], celio_k=10)
         ssys.add_linear_term(0, [1, 0, 0])  # Precession around x

--- a/muspinsim/tests/test_hamiltonian.py
+++ b/muspinsim/tests/test_hamiltonian.py
@@ -60,19 +60,14 @@ class TestHamiltonian(unittest.TestCase):
         # No operators => return a list of density operators
         evol = H.evolve(rho0, t)
 
-        print(evol[0].matrix)
-        print(evol[1].matrix)
-        print(evol[2].matrix)
-        print(evol[3].matrix)
-
         self.assertEqual(len(evol), 4)
         self.assertTrue(
             np.allclose(
                 evol[0].matrix.toarray(),
                 np.array(
                     [
-                        [1.00000000e00 + 0.0j, 2.23711432e-17 + 0.0j],
-                        [0.00000000e00 + 0.0j, 0.00000000e00 + 0.0j],
+                        [1.0 + 0.0j, 0.0 + 0.0j],
+                        [0.0 + 0.0j, 0.0 + 0.0j],
                     ]
                 ),
             )
@@ -82,14 +77,8 @@ class TestHamiltonian(unittest.TestCase):
                 evol[1].matrix.toarray(),
                 np.array(
                     [
-                        [
-                            2.50000000e-01 + 1.93784882e-18j,
-                            8.96010176e-18 + 4.33012702e-01j,
-                        ],
-                        [
-                            2.15404613e-17 - 4.33012702e-01j,
-                            7.50000000e-01 - 1.93784882e-18j,
-                        ],
+                        [0.25 + 0.0j, 0.0 + 0.433012702j],
+                        [0.0 - 0.433012702j, 0.75 + 0.0j],
                     ]
                 ),
             )
@@ -99,14 +88,8 @@ class TestHamiltonian(unittest.TestCase):
                 evol[2].matrix.toarray(),
                 np.array(
                     [
-                        [
-                            2.50000000e-01 - 6.69995273e-18j,
-                            -1.14184615e-18 - 4.33012702e-01j,
-                        ],
-                        [
-                            1.20162535e-17 + 4.33012702e-01j,
-                            7.50000000e-01 + 6.69995273e-18j,
-                        ],
+                        [0.25 - 0.0j, 0.0 - 0.433012702j],
+                        [0.0 + 0.433012702j, 0.75 + 0.0j],
                     ]
                 ),
             )
@@ -116,14 +99,8 @@ class TestHamiltonian(unittest.TestCase):
                 evol[3].matrix.toarray(),
                 np.array(
                     [
-                        [
-                            1.00000000e00 + 2.79557852e-33j,
-                            2.23711432e-17 - 1.22464680e-16j,
-                        ],
-                        [
-                            0.00000000e00 + 1.22464680e-16j,
-                            0.00000000e00 - 2.79557852e-33j,
-                        ],
+                        [1.0 + 0.0j, 0.0 + 0.0j],
+                        [0.0 + 0.0j, 0.0 + 0.0j],
                     ]
                 ),
             )

--- a/muspinsim/tests/test_hamiltonian.py
+++ b/muspinsim/tests/test_hamiltonian.py
@@ -47,6 +47,83 @@ class TestHamiltonian(unittest.TestCase):
 
         self.assertTrue(np.all(np.isclose(evol[:, 0], 0.5 * np.cos(2 * np.pi * t))))
 
+    def test_evolve_density(self):
+
+        ssys = SpinSystem(["e"])
+        ssys.add_linear_term(0, [1, 0, 0])  # Precession around x
+        H = ssys.hamiltonian
+        rho0 = DensityOperator.from_vectors()  # Start along z
+        t = np.linspace(0, 1, 4)
+
+        self.assertTrue(isinstance(H, Hamiltonian))
+
+        # No operators => return a list of density operators
+        evol = H.evolve(rho0, t)
+
+        self.assertEqual(len(evol), 4)
+        self.assertTrue(
+            np.allclose(
+                evol[0].matrix.toarray(),
+                np.array(
+                    [
+                        [1.00000000e00 + 0.0j, 2.23711432e-17 + 0.0j],
+                        [0.00000000e00 + 0.0j, 0.00000000e00 + 0.0j],
+                    ]
+                ),
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                evol[1].matrix.toarray(),
+                np.array(
+                    [
+                        [
+                            2.50000000e-01 + 1.93784882e-18j,
+                            8.96010176e-18 + 4.33012702e-01j,
+                        ],
+                        [
+                            2.15404613e-17 - 4.33012702e-01j,
+                            7.50000000e-01 - 1.93784882e-18j,
+                        ],
+                    ]
+                ),
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                evol[2].matrix.toarray(),
+                np.array(
+                    [
+                        [
+                            2.50000000e-01 - 6.69995273e-18j,
+                            -1.14184615e-18 - 4.33012702e-01j,
+                        ],
+                        [
+                            1.20162535e-17 + 4.33012702e-01j,
+                            7.50000000e-01 + 6.69995273e-18j,
+                        ],
+                    ]
+                ),
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                evol[3].matrix.toarray(),
+                np.array(
+                    [
+                        [
+                            1.00000000e00 + 2.79557852e-33j,
+                            2.23711432e-17 - 1.22464680e-16j,
+                        ],
+                        [
+                            0.00000000e00 + 1.22464680e-16j,
+                            0.00000000e00 - 2.79557852e-33j,
+                        ],
+                    ]
+                ),
+            )
+        )
+
     def test_fast_evolve(self):
 
         ssys = MuonSpinSystem(["mu", "e"])

--- a/muspinsim/tests/test_hamiltonian.py
+++ b/muspinsim/tests/test_hamiltonian.py
@@ -60,6 +60,11 @@ class TestHamiltonian(unittest.TestCase):
         # No operators => return a list of density operators
         evol = H.evolve(rho0, t)
 
+        print(evol[0].matrix)
+        print(evol[1].matrix)
+        print(evol[2].matrix)
+        print(evol[3].matrix)
+
         self.assertEqual(len(evol), 4)
         self.assertTrue(
             np.allclose(

--- a/muspinsim/tests/test_hamiltonian.py
+++ b/muspinsim/tests/test_hamiltonian.py
@@ -31,7 +31,7 @@ class TestHamiltonian(unittest.TestCase):
 
         Hrot = H.basis_change(evecs)
 
-        self.assertTrue(np.all(np.isclose(Hrot.matrix.toarray(), np.diag(evals))))
+        self.assertTrue(np.all(np.isclose(Hrot.matrix, np.diag(evals))))
 
     def test_evolve(self):
 

--- a/muspinsim/tests/test_lindbladian.py
+++ b/muspinsim/tests/test_lindbladian.py
@@ -124,8 +124,8 @@ class TestLindbladian(unittest.TestCase):
                 evol[3].matrix.toarray(),
                 np.array(
                     [
-                        [0.5 + 0.0000000e00j, 0.5 + 1.2246468e-16j],
-                        [0.5 - 1.2246468e-16j, 0.5 + 0.0000000e00j],
+                        [0.5 + 0.0j, 0.5 + 0.0j],
+                        [0.5 + 0.0j, 0.5 + 0.0j],
                     ]
                 ),
             )

--- a/muspinsim/tests/test_lindbladian.py
+++ b/muspinsim/tests/test_lindbladian.py
@@ -82,6 +82,55 @@ class TestLindbladian(unittest.TestCase):
             self.assertTrue(np.all(np.isclose(evol[:, 0], solx)))
             self.assertTrue(np.all(np.isclose(evol[:, 1], solz)))
 
+    def test_evolve_density(self):
+
+        # Basic test - no operator given so should return density matrices
+        sx = SpinOperator.from_axes()
+        sp = SpinOperator.from_axes(0.5, "+")
+        sm = SpinOperator.from_axes(0.5, "-")
+        sz = SpinOperator.from_axes(0.5, "z")
+
+        H = Hamiltonian(sz.matrix)
+        L = Lindbladian.from_hamiltonian(H)
+        rho0 = DensityOperator.from_vectors(0.5, [1, 0, 0], 0)
+        t = np.linspace(0, 1, 4)
+
+        evol = L.evolve(rho0, t)
+        self.assertEqual(len(evol), 4)
+        self.assertTrue(
+            np.allclose(
+                evol[0].matrix.toarray(),
+                np.array([[0.5 + 0.0j, 0.5 + 0.0j], [0.5 + 0.0j, 0.5 + 0.0j]]),
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                evol[1].matrix.toarray(),
+                np.array(
+                    [[0.5 + 0.0j, -0.25 - 0.4330127j], [-0.25 + 0.4330127j, 0.5 + 0.0j]]
+                ),
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                evol[2].matrix.toarray(),
+                np.array(
+                    [[0.5 + 0.0j, -0.25 + 0.4330127j], [-0.25 - 0.4330127j, 0.5 + 0.0j]]
+                ),
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                evol[3].matrix.toarray(),
+                np.array(
+                    [
+                        [0.5 + 0.0000000e00j, 0.5 + 1.2246468e-16j],
+                        [0.5 - 1.2246468e-16j, 0.5 + 0.0000000e00j],
+                    ]
+                ),
+            )
+        )
+
     def test_integrate(self):
 
         # Basic test

--- a/muspinsim/tests/test_spinop.py
+++ b/muspinsim/tests/test_spinop.py
@@ -198,6 +198,40 @@ class TestSpinOperator(unittest.TestCase):
             )
         )
 
+        # Normalisation
+        density_op = DensityOperator(np.eye(4) * 10)
+        density_op.normalize()
+        np.testing.assert_allclose(density_op.matrix.toarray(), np.eye(4) / 4)
+
+    def test_density_dense(self):
+
+        rho = DensityOperator(np.eye(6) / 6.0, (2, 3), use_sparse=False)
+        rhosmall = rho.partial_trace([1])
+
+        self.assertEqual(rhosmall.dimension, (2,))
+        self.assertTrue(np.all(np.isclose(rhosmall.matrix, np.eye(2) / 2)))
+
+        with self.assertRaises(ValueError):
+            DensityOperator(np.array([[0, 1], [1, 0]]), use_sparse=False)
+
+        with self.assertRaises(ValueError):
+            DensityOperator(np.array([[1, 1], [0, 1]]), use_sparse=False)
+
+        rho = DensityOperator.from_vectors(0.5, [1, 0, 0], use_sparse=False)
+
+        self.assertTrue(np.all(rho.matrix == np.ones((2, 2)) * 0.5))
+
+        rho = DensityOperator.from_vectors(0.5, [0, 1, 0], 0.5, use_sparse=False)
+
+        self.assertTrue(
+            np.all(np.isclose(rho.matrix, np.array([[0.5, -0.25j], [0.25j, 0.5]])))
+        )
+
+        # Normalisation
+        density_op = DensityOperator(np.eye(4) * 10, use_sparse=False)
+        density_op.normalize()
+        np.testing.assert_allclose(density_op.matrix, np.eye(4) / 4)
+
     def test_superoperator(self):
 
         sx = SpinOperator.from_axes()

--- a/muspinsim/tests/test_spinop.py
+++ b/muspinsim/tests/test_spinop.py
@@ -111,6 +111,48 @@ class TestSpinOperator(unittest.TestCase):
         sx = SpinOperator.from_axes(0.5, "x")
         self.assertEqual(2 * np.real(rho.hilbert_schmidt(sx)), 0.5**0.5)
 
+    def test_operations_dense(self):
+
+        sx = SpinOperator.from_axes(0.5, "x", use_sparse=False)
+        sy = SpinOperator.from_axes(0.5, "y", use_sparse=False)
+        sz = SpinOperator.from_axes(0.5, "z", use_sparse=False)
+
+        # Scalar operations
+        self.assertTrue(np.all((2 * sx).matrix == [[0, 1], [1, 0]]))
+        self.assertTrue(np.all((sx / 2).matrix == [[0, 0.25], [0.25, 0]]))
+
+        # Operators (test commutation relations)
+        self.assertTrue(np.all((sx * sy - sy * sx).matrix == (1.0j * sz).matrix))
+        self.assertTrue(np.all((sy * sz - sz * sy).matrix == (1.0j * sx).matrix))
+        self.assertTrue(np.all((sz * sx - sx * sz).matrix == (1.0j * sy).matrix))
+
+        self.assertTrue(np.all((sx + 0.5).matrix == 0.5 * np.ones((2, 2))))
+        self.assertTrue(np.all((sz - 0.5).matrix == np.diag([0, -1])))
+
+        # Test equality
+        self.assertTrue(
+            np.allclose(
+                sx.matrix.data,
+                SpinOperator.from_axes(0.5, "x", use_sparse=False).matrix.data,
+            )
+        )
+        self.assertFalse(SpinOperator(np.eye(4)) == SpinOperator(np.eye(4), (2, 2)))
+
+        # Test Kronecker product
+        sxsz = sx.kron(sz)
+        self.assertEqual(sxsz.dimension, (2, 2))
+        self.assertTrue(
+            np.all(
+                4 * sxsz.matrix
+                == [[0, 0, 1, 0], [0, 0, 0, -1], [1, 0, 0, 0], [0, -1, 0, 0]]
+            )
+        )
+
+        # Test Hilbert-Schmidt product
+        rho = DensityOperator.from_vectors(0.5, np.array([1, 1, 0]) / 2**0.5)
+        sx = SpinOperator.from_axes(0.5, "x", use_sparse=False)
+        self.assertEqual(2 * np.real(rho.hilbert_schmidt(sx)), 0.5**0.5)
+
     def test_multi(self):
 
         Sx = SpinOperator.from_axes()

--- a/muspinsim/tests/test_validation.py
+++ b/muspinsim/tests/test_validation.py
@@ -70,3 +70,7 @@ class TestValidation(unittest.TestCase):
                 10,
                 [SpinOperator.from_axes(), 2],
             )
+
+        # No SpinOperators
+        with self.assertRaises(TypeError):
+            validate_integrate_decaying_params(10, 10, [])

--- a/muspinsim/validation.py
+++ b/muspinsim/validation.py
@@ -58,14 +58,18 @@ def validate_integrate_decaying_params(rho0, tau, operators):
     Raises:
         TypeError -- Invalid operators
         ValueError -- Invalid values of tau or operators
+        ValueError -- If 'operators' is empty
     """
     if not isinstance(rho0, DensityOperator):
-        raise TypeError("rho0 must be a valid DensityOperator")
+        raise TypeError("'rho0' must be a valid DensityOperator")
 
     if not (isinstance(tau, Number) and np.isreal(tau) and tau > 0):
-        raise ValueError("tau must be a real number > 0")
+        raise ValueError("'tau' must be a real number > 0")
+
+    if not operators:
+        raise ValueError("At least one SpinOperator must be present in 'operators'")
 
     if not all([isinstance(o, SpinOperator) for o in operators]):
         raise ValueError(
-            "operators must be a SpinOperator or a list of SpinOperator objects"
+            "'operators' must be a SpinOperator or a list of SpinOperator objects"
         )


### PR DESCRIPTION
Changes I made when looking into speeding up the sparse matrix usage. May be overridden in the future by removing sparse matrices altogether.

Using
```
name
    Test
spins
    e mu H
hyperfine 2
    580 5   10
    5   580 9
    10  9   580
hyperfine 3
    150 3   4
    3   150 5
    4   5   150
orientation
    zcw(20)
field
    range(1.8, 2.6, 100)
experiment
    alc
```
as a baseline, v1.2.0 takes ~ 5 seconds.

- Stopped converting eigenvectors to a csr_matrix (this was always 100% dense in my testing)
   This increased the performance of from ~29 seconds down to ~24
- Stopped generating Hz using sparse matrices in experiment.py's rho0 computation as this was made to be dense immediately after again - further reduction down to ~20 seconds

Checking against a largish system using ~480Mb (without celios) suggests the memory usage change is negligible. I think the source of most of the large matrices are now from `self._single_spinops` in experiment.py. Which are still all sparse.

Also checked all the examples are still working.