### PR TITLE
Avoiding Kronecker products using method similar Celio's #74

### DIFF
--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -179,14 +179,16 @@ class ExperimentRunner:
                     r = DensityOperator.from_vectors(I, muon_axis, 0)
                 else:
                     # Get the Zeeman Hamiltonian for this field
+                    # Don't bother using sparse, we need them dense for eigh
+                    # anyway
                     Hz = np.sum(
                         [
-                            B[j] * SpinOperator.from_axes(I, e).matrix
+                            B[j] * SpinOperator.from_axes(I, e, use_sparse=False).matrix
                             for j, e in enumerate("xyz")
                         ],
                         axis=0,
                     )
-                    evals, evecs = np.linalg.eigh(Hz.toarray())
+                    evals, evecs = np.linalg.eigh(Hz)
                     E = evals * 1e6 * self._system.gamma(i)
 
                     if T > 0:

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -84,13 +84,13 @@ class ExperimentRunner:
         # Store single spin operators (only needed for dispersion
         # and non other non celio methods)
         # Large source of memory usage
-        if not self.config.celio_k:
-            self._single_spinops = np.array(
-                [
-                    [self._system.operator({i: a}).matrix for a in "xyz"]
-                    for i in range(len(self._system))
-                ]
-            )
+        # if not self.config.celio_k:
+        #     self._single_spinops = np.array(
+        #         [
+        #             [self._system.operator({i: a}).matrix for a in "xyz"]
+        #             for i in range(len(self._system))
+        #         ]
+        #     )
 
         # Parameters
         self._B = np.zeros(3)

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -83,6 +83,7 @@ class ExperimentRunner:
 
         # Store single spin operators (only needed for dispersion
         # and non other non celio methods)
+        # Large source of memory usage
         if not self.config.celio_k:
             self._single_spinops = np.array(
                 [

--- a/muspinsim/hamiltonian.py
+++ b/muspinsim/hamiltonian.py
@@ -76,12 +76,10 @@ class Hamiltonian(Operator, Hermitian):
 
         # Turn the density matrix in the right basis
         dim = rho0.dimension
-        rho0 = rho0.basis_change(evecs).matrix.toarray()
+        rho0 = rho0.basis_change(evecs).matrix
 
         # Same for operators
-        operatorsT = np.array(
-            [o.basis_change(evecs).matrix.T.toarray() for o in operators]
-        )
+        operatorsT = np.array([o.basis_change(evecs).matrix.T for o in operators])
 
         # Matrix of evolution operators
         ll = -2.0j * np.pi * (evals[:, None] - evals[None, :])
@@ -151,16 +149,13 @@ class Hamiltonian(Operator, Hermitian):
         evals, evecs = self.diag()
 
         # Turn the density matrix in the right basis
-        rho0 = rho0.basis_change(evecs).matrix.toarray()
+        rho0 = rho0.basis_change(evecs).matrix
 
         ll = 2.0j * np.pi * (evals[:, None] - evals[None, :])
 
         # Integral operators
         intops = np.array(
-            [
-                (-o.basis_change(evecs).matrix.toarray() / (ll - 1.0 / tau)).T
-                for o in operators
-            ]
+            [(-o.basis_change(evecs).matrix / (ll - 1.0 / tau)).T for o in operators]
         )
 
         result = np.sum(rho0[None, :, :] * intops[:, :, :], axis=(1, 2))

--- a/muspinsim/hamiltonian.py
+++ b/muspinsim/hamiltonian.py
@@ -17,19 +17,21 @@ from muspinsim.validation import (
 
 
 class Hamiltonian(Operator, Hermitian):
-    def __init__(self, matrix, dim=None):
+    def __init__(self, matrix, dim=None, use_sparse=True):
         """Create an Hamiltonian
 
         Create an Hamiltonian from a hermitian complex matrix
 
         Arguments:
             matrix {ndarray} -- Matrix representation of the Hamiltonian
+            dim {(int,...)} -- See Operator
+            use_sparse {bool} -- See Operator
 
         Raises:
             ValueError -- Matrix isn't square or hermitian
         """
 
-        super(Hamiltonian, self).__init__(matrix, dim)
+        super(Hamiltonian, self).__init__(matrix, dim, use_sparse=use_sparse)
 
     @classmethod
     def from_spin_operator(self, spinop):

--- a/muspinsim/hamiltonian2.py
+++ b/muspinsim/hamiltonian2.py
@@ -1,0 +1,354 @@
+"""hamiltonian.py
+
+A class describing a spin Hamiltonian with various terms
+"""
+
+from typing import List
+import numpy as np
+from dataclasses import dataclass
+import itertools
+import logging
+from typing import List
+from qutip import Qobj
+
+from scipy import sparse
+from muspinsim.celio import CelioHContrib
+
+from muspinsim.cython import parallel_fast_time_evolve
+from muspinsim.spinop import SpinOperator, DensityOperator, Operator, Hermitian
+from muspinsim.validation import (
+    validate_evolve_params,
+    validate_integrate_decaying_params,
+    validate_times,
+)
+
+
+class Hamiltonian2(Operator, Hermitian):
+    def __init__(self, terms, spinsys):
+        """Create a CelioHamiltonian
+
+        Create a CelioHamiltonian for applying Celio's method
+
+        Arguments:
+            terms {[InteractionTerm]} -- Interaction terms that will form part of the
+                                         Trotter expansion
+            k {int} -- Factor to be used in the Trotter expansion
+            spinsys {SpinSystem} -- SpinSystem required for computing the time evolution
+        """
+        self._terms = terms
+        self._spinsys = spinsys
+
+    def __add__(self, x):
+        return Hamiltonian2(self._terms + x._terms, self._spinsys)
+
+    def _calc_H_contribs(self) -> List[CelioHContrib]:
+        """Calculates and returns the Hamiltonian contributions required for Celio's
+           method
+
+        Returns the hamiltonian contributions defined by this system of spins and the
+        given interactions. In general these are split up per group of indices defined
+        in interactions to minimise the need of matrix exponentials.
+
+        Returns:
+            H_contribs {[CelioHContrib]} -- List of matrices representing contributions
+                                            to the total system hamiltonians referred to
+                                            in Celio's method as H_i
+        """
+
+        spin_indices = range(0, len(self._spinsys.spins))
+
+        H_contribs = []
+
+        for i in spin_indices:
+            # Only want to include each interaction once, will make the choice here to
+            # only add it to the H_i for the first particle listed in the interactions
+
+            # Find the terms that have the current spin as its first or only index
+            spin_ints = [term for term in (self._terms) if i == term.indices[0]]
+
+            # List of spin indices not included here
+            other_spins = list(range(0, len(self._spinsys.spins)))
+            other_spins.remove(i)
+
+            # Only include necessary terms
+            if len(spin_ints) != 0:
+                # Sum matrices with the same indices so we avoid lots of matrix
+                # exponentials
+                for indices, group in itertools.groupby(
+                    spin_ints, lambda term: term.indices
+                ):
+
+                    grouped_spin_ints = list(group)
+                    H_contrib = np.sum([term.matrix for term in grouped_spin_ints])
+
+                    # Find indices of spins not involved in the current interactions
+                    uninvolved_spins = other_spins.copy()
+                    for term in grouped_spin_ints:
+                        for j in term.indices:
+                            if j in uninvolved_spins:
+                                uninvolved_spins.remove(j)
+
+                    other_dimension = np.product(
+                        [self._spinsys.dimension[j] for j in uninvolved_spins]
+                    )
+
+                    # Detect Quadrupolar terms which will have the same index twice
+                    indices = list(indices)
+                    if len(indices) == 2 and indices[0] == indices[1]:
+                        # Only include one of them for the ordering
+                        indices.pop()
+
+                    # Order in which kronecker products will be performed in Celio's
+                    # method and the corresponding dimensions
+                    spin_order = indices + uninvolved_spins
+                    spin_dimensions = [self._spinsys.dimension[i] for i in spin_order]
+
+                    H_contribs.append(
+                        CelioHContrib(
+                            H_contrib,
+                            other_dimension,
+                            spin_order,
+                            spin_dimensions,
+                        )
+                    )
+
+        return H_contribs
+
+    def _calc_full_hamiltonian(self):
+        """Calculates and returns the contributions to the Trotter expansion of
+        the time evolution operator computed from the Hamiltonian contributions
+
+        Arguments:
+            time_step {float} -- Timestep that will be used during the evolution
+            cpp {boolean} -- When true will calculate ready for use with the C++
+                             version
+
+        Returns:
+            evol_op_contribs {[matrix]} -- Contributions to the Trotter expansion
+                                           of the evolution operator
+        """
+
+        H_contribs = self._calc_H_contribs()
+
+        total_H = None
+
+        for H_contrib in H_contribs:
+            # The matrix is currently stored in csr format, but expm wants it
+            # in csc so convert here
+            evol_op_contrib = H_contrib.matrix
+
+            # Python version - requires kronecker products
+            if H_contrib.other_dimension > 1:
+                evol_op_contrib = sparse.kron(
+                    evol_op_contrib,
+                    sparse.identity(H_contrib.other_dimension, format="csr"),
+                )
+
+            # For particle interactions that are not neighbors we must use
+            # a swap gate
+            qtip_obj = Qobj(
+                inpt=evol_op_contrib,
+                dims=[H_contrib.spin_dimensions, H_contrib.spin_dimensions],
+            )
+            # Order we need to permute in order to obtain the same order
+            # as was given in the input
+            permute_order = np.argsort(H_contrib.spin_order)
+
+            qtip_obj = qtip_obj.permute(permute_order)
+            evol_op_contrib = qtip_obj.data
+
+            if total_H is None:
+                total_H = evol_op_contrib
+            else:
+                total_H += evol_op_contrib
+
+        return total_H
+
+    @classmethod
+    def from_spin_operator(self, spinop):
+        return self(spinop.matrix, spinop.dimension)
+
+    def diag(self):
+        total_H = self._calc_full_hamiltonian()
+
+        return np.linalg.eigh(total_H.toarray())
+
+    def evolve(self, rho0, times, operators=None):
+        """Time evolution of a state under this Hamiltonian
+
+        Perform an evolution of a state described by a DensityOperator under
+        this Hamiltonian and return either a sequence of DensityOperators or
+        a sequence of expectation values for given SpinOperators.
+
+        Arguments:
+            rho0 {DensityOperator} -- Initial state
+            times {ndarray} -- Times to compute the evolution for, in microseconds
+
+        Keyword Arguments:
+            operators {[SpinOperator]} -- List of SpinOperators to compute the
+                                          expectation values of at each step.
+                                          If omitted, the states' density
+                                          matrices will be returned instead
+                                           (default: {[]})
+
+        Returns:
+            [DensityOperator | ndarray] -- DensityOperators or expectation values
+
+        Raises:
+            TypeError -- Invalid operators
+            ValueError -- Invalid values of times or operators
+            RuntimeError -- Hamiltonian is not hermitian
+        """
+        if operators is None:
+            operators = []
+
+        times = np.array(times)
+
+        if isinstance(operators, SpinOperator):
+            operators = [operators]
+
+        validate_evolve_params(rho0, times, operators)
+
+        # Diagonalize self
+        evals, evecs = self.diag()
+
+        # Turn the density matrix in the right basis
+        dim = rho0.dimension
+        rho0 = rho0.basis_change(evecs).matrix
+
+        # Same for operators
+        operatorsT = np.array([o.basis_change(evecs).matrix.T for o in operators])
+
+        # Matrix of evolution operators
+        ll = -2.0j * np.pi * (evals[:, None] - evals[None, :])
+
+        def calc_single_rho(i):
+            return np.exp(ll[None, :, :] * times[i, None, None]) * rho0[None, :, :]
+
+        result = None
+        if len(operators) > 0:
+            # Actually compute expectation values one at a time
+            for i in range(times.shape[0]):
+                rho = calc_single_rho(i)
+
+                # This element wise multiplication then sum gives the equivalent
+                # as the trace of the matrix product (without the transpose) and
+                # and is faster
+                single_res = np.sum(
+                    rho[0, None, :, :] * operatorsT[None, :, :, :], axis=(2, 3)
+                )
+                if result is None:
+                    result = single_res
+                else:
+                    result = np.concatenate(([result, single_res]), axis=0)
+        else:
+            sceve = evecs.T.conj()
+            for i in range(times.shape[0]):
+                # Just return density matrices
+                result = [
+                    DensityOperator(calc_single_rho(i), dim).basis_change(sceve)
+                    for i in range(times.shape[0])
+                ]
+        return result
+
+    def integrate_decaying(self, rho0, tau, operators=None):
+        """Integrate one or more expectation values in time with decay
+
+        Perform an integral in time from 0 to +inf of an expectation value
+        computed on an evolving state, times a decay factor exp(-t/tau).
+        This can be done numerically using evolve, but here is executed with
+        a single evaluation, making it a lot faster.
+
+        Arguments:
+            rho0 {DensityOperator} -- Initial state
+            tau {float} -- Decay time, in microseconds
+
+        Keyword Arguments:
+            operators {list} -- Operators to compute the expectation values
+                                of (default: {[]})
+
+        Returns:
+            ndarray -- List of integral values
+
+        Raises:
+            TypeError -- Invalid operators
+            ValueError -- Invalid values of tau or operators
+            RuntimeError -- Hamiltonian is not hermitian
+        """
+        if operators is None:
+            operators = []
+
+        if isinstance(operators, SpinOperator):
+            operators = [operators]
+
+        validate_integrate_decaying_params(rho0, tau, operators)
+
+        # Diagonalize self
+        evals, evecs = self.diag()
+
+        # Turn the density matrix in the right basis
+        rho0 = rho0.basis_change(evecs).matrix
+
+        ll = 2.0j * np.pi * (evals[:, None] - evals[None, :])
+
+        # Integral operators
+        intops = np.array(
+            [(-o.basis_change(evecs).matrix / (ll - 1.0 / tau)).T for o in operators]
+        )
+
+        result = np.sum(rho0[None, :, :] * intops[:, :, :], axis=(1, 2))
+
+        return result
+
+    def fast_evolve(self, sigma_mu, times, other_dimension):
+        """Compute time evolution of a muon polarisation state using this
+           Hamiltonian
+
+        Computes the evolution of a muon polarisation state under this
+        Hamiltonian and returns a sequence of expectation values.
+
+        The muon polarisation is assumed to be first in the system in this
+        computation.
+
+        Arguments:
+            sigma_mu {ndarray} -- Linear combination of Pauli spin matrices in
+                                  the direction of the muon
+            times {ndarray} -- Times to compute the evolution for, in microseconds
+            other_dimension {int} -- Combined dimension of all non-muons in the
+                                     system
+
+        Returns:
+            [ndarray] -- Expectation values
+
+        Raises:
+            ValueError -- Invalid values of times
+            RuntimeError -- Hamiltonian is not hermitian
+        """
+
+        times = np.array(times)
+
+        validate_times(times)
+
+        # Diagonalize self
+        evals, evecs = self.diag()
+
+        # Expand to correct size (Assumes the muon is the first element in
+        # the system)
+        # Note: May be able to adapt method from C++ implementation of Celio's
+        # to avoid the use of kron here to reduce memory and speed up -
+        # although limiting factor at the moment is still the eigenvalue
+        # computation
+        sigma_mu = sparse.kron(sigma_mu, sparse.identity(other_dimension, format="csr"))
+
+        # Compute the value of R^dagger * sigma * R
+        A = np.dot(evecs.T.conjugate(), np.dot(sigma_mu.toarray(), evecs))
+
+        # Mod square
+        A = np.power(np.abs(A), 2)
+        W = 2 * np.pi * np.subtract.outer(evals, evals)
+
+        results = parallel_fast_time_evolve(times, other_dimension, A, W)
+
+        # Divide by 2 as by convention rest of muspinsim gives results between
+        # 0.5 and -0.5
+        return results * 0.5

--- a/muspinsim/hamiltonian2.py
+++ b/muspinsim/hamiltonian2.py
@@ -301,8 +301,6 @@ class Hamiltonian2(Operator, Hermitian):
         if N > 1900:
             print(TOTAL_TIME)
 
-        print(type(rho0.matrix))
-
         # Turn the density matrix in the right basis
         rho0 = rho0.basis_change(evecs).matrix
 

--- a/muspinsim/spinop.py
+++ b/muspinsim/spinop.py
@@ -85,7 +85,7 @@ class Hermitian:
 
 
 class Operator(Clonable):
-    def __init__(self, matrix, dim=None, herm_tol=1e-6, use_sparse=True):
+    def __init__(self, matrix, dim=None, herm_tol=1e-6, use_sparse=False):
         """Create a Operator object
 
         Create an object representing a spin operator. These can
@@ -360,7 +360,7 @@ class Operator(Clonable):
 
 class SpinOperator(Operator):
     @classmethod
-    def from_axes(self, Is=0.5, axes="x", use_sparse=True):
+    def from_axes(self, Is=0.5, axes="x", use_sparse=False):
         """Construct a SpinOperator from spins and axes
 
         Construct a SpinOperator from a list of spin values and directions. For

--- a/muspinsim/spinop.py
+++ b/muspinsim/spinop.py
@@ -416,7 +416,7 @@ class SpinOperator(Operator):
 
 
 class DensityOperator(Operator):
-    def __init__(self, matrix, dim=None, use_sparse=True):
+    def __init__(self, matrix, dim=None, use_sparse=False):
         """Create a DensityOperator object
 
         Create an object representing a density operator. These can
@@ -532,7 +532,10 @@ class DensityOperator(Operator):
 
     def normalize(self):
         """Normalize this DensityOperator to have trace equal to one."""
-        self._matrix = self._matrix.multiply(1 / self.trace)
+        if self._sparse:
+            self._matrix = self._matrix.multiply(1 / self.trace)
+        else:
+            self._matrix *= 1 / self.trace
 
     def partial_trace(self, trace_dim=None):
         """Perform a partial trace operation

--- a/muspinsim/spinop.py
+++ b/muspinsim/spinop.py
@@ -85,7 +85,7 @@ class Hermitian:
 
 
 class Operator(Clonable):
-    def __init__(self, matrix, dim=None, herm_tol=1e-6):
+    def __init__(self, matrix, dim=None, herm_tol=1e-6, use_sparse=True):
         """Create a Operator object
 
         Create an object representing a spin operator. These can
@@ -103,12 +103,18 @@ class Operator(Clonable):
                                the matrix (default: {None})
             herm_tol {float} -- Tolerance used to check for hermitianity of the
                                matrix (default: {1e-6})
+            use_sparse {bool} -- Determines whether to use sparse matrices for
+                                 storing this operator's matrix
 
         Raises:
             ValueError -- Any of the passed values are invalid
         """
-        # use sparse matrices
-        self._matrix = sparse.csr_matrix(matrix)
+        self._sparse = use_sparse
+
+        if self._sparse:
+            self._matrix = sparse.csr_matrix(matrix)
+        else:
+            self._matrix = np.array(matrix)
 
         if not matrix.shape[0] == matrix.shape[1]:
             raise ValueError("Matrix passed to Operator must be square")
@@ -159,6 +165,7 @@ class Operator(Clonable):
         ans = MyClass.__new__(MyClass)
         ans._dim = tuple(self._dim)
         ans._matrix = self.matrix.conjugate().T
+        ans._sparse = self._sparse
 
         return ans
 
@@ -179,7 +186,10 @@ class Operator(Clonable):
         elif isinstance(x, Number):
 
             ans = self.clone()
-            ans._matrix += sparse.eye(ans._matrix.shape[0]) * x
+            if self._sparse:
+                ans._matrix += sparse.eye(ans._matrix.shape[0]) * x
+            else:
+                ans._matrix += np.eye(ans._matrix.shape[0]) * x
 
             return ans
 
@@ -215,14 +225,22 @@ class Operator(Clonable):
                 )
 
             ans = self.clone()
-            ans._matrix = ans._matrix.dot(x._matrix)
+
+            if self._sparse:
+                ans._matrix = ans._matrix.dot(x._matrix)
+            else:
+                ans._matrix = ans._matrix @ x._matrix
 
             return ans
 
         elif isinstance(x, Number):
 
             ans = self.clone()
-            ans._matrix = ans._matrix.multiply(x)
+
+            if self._sparse:
+                ans._matrix = ans._matrix.multiply(x)
+            else:
+                ans._matrix *= x
 
             return ans
 
@@ -277,7 +295,12 @@ class Operator(Clonable):
         # Doing it this way saves some time
         ans = self.__class__.__new__(self.__class__)
         ans._dim = self._dim + x._dim
-        ans._matrix = sparse.kron(self._matrix, x._matrix, format="csr")
+        ans._sparse = self._sparse
+
+        if self._sparse:
+            ans._matrix = sparse.kron(self._matrix, x._matrix, format="csr")
+        else:
+            ans._matrix = np.kron(self._matrix, x._matrix)
 
         return ans
 
@@ -337,7 +360,7 @@ class Operator(Clonable):
 
 class SpinOperator(Operator):
     @classmethod
-    def from_axes(self, Is=0.5, axes="x"):
+    def from_axes(self, Is=0.5, axes="x", use_sparse=True):
         """Construct a SpinOperator from spins and axes
 
         Construct a SpinOperator from a list of spin values and directions. For
@@ -350,6 +373,8 @@ class SpinOperator(Operator):
             axes {[str]} -- List of axes, can pass a single character if it's
                             only one value. Each value can be x, y, z, +, -,
                             or 0 (for the identity operator) (default: {'x'})
+            use_sparse {bool} -- Whether to use a sparse matrix for storing the
+                                 generated operator's matrix
 
         Returns:
             SpinOperator -- Operator built according to specifications
@@ -387,11 +412,11 @@ class SpinOperator(Operator):
         for m in matrices[1:]:
             M = np.kron(M, m)
 
-        return self(sparse.csr_matrix(M), dim=dim)
+        return self(M, dim=dim, use_sparse=use_sparse)
 
 
 class DensityOperator(Operator):
-    def __init__(self, matrix, dim=None):
+    def __init__(self, matrix, dim=None, use_sparse=True):
         """Create a DensityOperator object
 
         Create an object representing a density operator. These can
@@ -412,7 +437,7 @@ class DensityOperator(Operator):
         Raises:
             ValueError -- Any of the passed values are invalid
         """
-        super(DensityOperator, self).__init__(matrix, dim)
+        super(DensityOperator, self).__init__(matrix, dim, use_sparse=use_sparse)
         # Enforce unitarity
 
         tr = self._matrix.trace()
@@ -499,7 +524,7 @@ class DensityOperator(Operator):
         for m in matrices[1:]:
             M = np.kron(M, m)
 
-        return self(sparse.csr_matrix(M), dim=dim)
+        return self(M, dim=dim)
 
     @property
     def trace(self):

--- a/muspinsim/spinop.py
+++ b/muspinsim/spinop.py
@@ -329,9 +329,8 @@ class Operator(Clonable):
         """
 
         ans = self.clone()
-        basis = sparse.csr_matrix(basis)
         x = basis.T.conjugate()
-        ans._matrix = x.dot(ans._matrix).dot(basis)
+        ans._matrix = x @ ans._matrix @ basis
 
         return ans
 

--- a/muspinsim/spinsys.py
+++ b/muspinsim/spinsys.py
@@ -12,6 +12,7 @@ from scipy import sparse
 from qutip import sigmax, sigmay, sigmaz
 
 from muspinsim.celio import CelioHamiltonian
+from muspinsim.hamiltonian2 import Hamiltonian2
 from muspinsim.utils import Clonable
 from muspinsim.spinop import SpinOperator
 from muspinsim.hamiltonian import Hamiltonian
@@ -49,7 +50,7 @@ class InteractionTerm(Clonable):
                 op = (
                     self._spinsys.operator(
                         {self.indices[0]: ["xyz"[ii[0]], "xyz"[ii[1]]]},
-                        include_only_given=self._spinsys.celio_k,
+                        include_only_given=True,
                     )
                     * self._tensor[tuple(ii)]
                 )
@@ -58,7 +59,7 @@ class InteractionTerm(Clonable):
                 op = (
                     self._spinsys.operator(
                         {ind: "xyz"[ii[i]] for i, ind in enumerate(self._indices)},
-                        include_only_given=self._spinsys.celio_k,
+                        include_only_given=True,
                     )
                     * self._tensor[tuple(ii)]
                 )
@@ -622,12 +623,13 @@ class SpinSystem(Clonable):
     def hamiltonian(self):
         H = None
         if not self._celio_k:
-            if len(self._terms) == 0:
-                n = np.prod(self.dimension)
-                H = sparse.csr_matrix((n, n))
-            else:
-                H = np.sum([t.matrix for t in self._terms], axis=0)
-            H = Hamiltonian(H, dim=self.dimension)
+            # if len(self._terms) == 0:
+            #     n = np.prod(self.dimension)
+            #     H = sparse.csr_matrix((n, n))
+            # else:
+            #     H = np.sum([t.matrix for t in self._terms], axis=0)
+            # H = Hamiltonian(H, dim=self.dimension)
+            H = Hamiltonian2(self._terms, self)
         else:
             H = CelioHamiltonian(self._terms, self._celio_k, self)
 

--- a/muspinsim/tests/test_hamiltonian.py
+++ b/muspinsim/tests/test_hamiltonian.py
@@ -31,7 +31,7 @@ class TestHamiltonian(unittest.TestCase):
 
         Hrot = H.basis_change(evecs)
 
-        self.assertTrue(np.all(np.isclose(Hrot.matrix.toarray(), np.diag(evals))))
+        self.assertTrue(np.all(np.isclose(Hrot.matrix, np.diag(evals))))
 
     def test_evolve(self):
 

--- a/muspinsim/tests/test_spinop.py
+++ b/muspinsim/tests/test_spinop.py
@@ -111,6 +111,48 @@ class TestSpinOperator(unittest.TestCase):
         sx = SpinOperator.from_axes(0.5, "x")
         self.assertEqual(2 * np.real(rho.hilbert_schmidt(sx)), 0.5**0.5)
 
+    def test_operations_dense(self):
+
+        sx = SpinOperator.from_axes(0.5, "x", use_sparse=False)
+        sy = SpinOperator.from_axes(0.5, "y", use_sparse=False)
+        sz = SpinOperator.from_axes(0.5, "z", use_sparse=False)
+
+        # Scalar operations
+        self.assertTrue(np.all((2 * sx).matrix == [[0, 1], [1, 0]]))
+        self.assertTrue(np.all((sx / 2).matrix == [[0, 0.25], [0.25, 0]]))
+
+        # Operators (test commutation relations)
+        self.assertTrue(np.all((sx * sy - sy * sx).matrix == (1.0j * sz).matrix))
+        self.assertTrue(np.all((sy * sz - sz * sy).matrix == (1.0j * sx).matrix))
+        self.assertTrue(np.all((sz * sx - sx * sz).matrix == (1.0j * sy).matrix))
+
+        self.assertTrue(np.all((sx + 0.5).matrix == 0.5 * np.ones((2, 2))))
+        self.assertTrue(np.all((sz - 0.5).matrix == np.diag([0, -1])))
+
+        # Test equality
+        self.assertTrue(
+            np.allclose(
+                sx.matrix.data,
+                SpinOperator.from_axes(0.5, "x", use_sparse=False).matrix.data,
+            )
+        )
+        self.assertFalse(SpinOperator(np.eye(4)) == SpinOperator(np.eye(4), (2, 2)))
+
+        # Test Kronecker product
+        sxsz = sx.kron(sz)
+        self.assertEqual(sxsz.dimension, (2, 2))
+        self.assertTrue(
+            np.all(
+                4 * sxsz.matrix
+                == [[0, 0, 1, 0], [0, 0, 0, -1], [1, 0, 0, 0], [0, -1, 0, 0]]
+            )
+        )
+
+        # Test Hilbert-Schmidt product
+        rho = DensityOperator.from_vectors(0.5, np.array([1, 1, 0]) / 2**0.5)
+        sx = SpinOperator.from_axes(0.5, "x", use_sparse=False)
+        self.assertEqual(2 * np.real(rho.hilbert_schmidt(sx)), 0.5**0.5)
+
     def test_multi(self):
 
         Sx = SpinOperator.from_axes()


### PR DESCRIPTION
This PR is a bit of a mess and should not be merged unless cleaned up and thoroughly tested. It essentially copies CelioHamiltonian and Hamiltonian into a class `Hamiltonian2` and keeps all interaction matrices small, constructing the full hamiltonian only when its about to be diagonalized. Its based on #79 and uses dense matrices everywhere.

The system
```
name
    Test
spins
    e mu H
hyperfine 2
    580 5   10
    5   580 9
    10  9   580
hyperfine 3
    150 3   4
    3   150 5
    4   5   150
orientation
    zcw(20)
field
    range(1.8, 2.6, 100)
experiment
    alc
```
Takes ~11 seconds, and
```
name
   Test
spins
   mu 13e 13e 5e
dipolar 1 2
   0 0 1
dipolar 1 3
   0 0 -1
dipolar 1 4
   0 0 1
time
   range(0, 0.1, 500)
```
Goes from using 800Mb down to 500, and from 298 seconds down to 60. The performance can likely be further improved using  parallelised C++ for constructing the Hamiltonian. Most of the memory usage saving is actually due to commenting out the construction of `self._single_spinops` in experiment.py. This should only be done if absolutely necessary as the matrices are all large. Its only used in dissipation. Perhaps this should just be left as sparse for the time being?