### PR TITLE
Fix ALC fitting #81

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -58,8 +58,8 @@ keywords:
   - "muon experiments: zero field"
 license: MIT
 # version data
-version: v2.2.1
-date-released: '2023-03-14'
+version: v2.3.0
+date-released: '2023-03-30'
 doi: 10.5281/zenodo.7733979
 identifiers:
   - type: doi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -59,7 +59,7 @@ keywords:
 license: MIT
 # version data
 version: v2.3.0
-date-released: '2023-03-30'
+date-released: '2023-04-03'
 doi: 10.5281/zenodo.7733979
 identifiers:
   - type: doi

--- a/docs/docs/input.md
+++ b/docs/docs/input.md
@@ -383,6 +383,8 @@ fitting_tolerance
 
 Tolerance for the fitting. When using `nelder-mead` (default) or `lbfgs` it's used as the `tol` parameter in SciPy's `scipy.optimize.minimize` method; exact meaning depends on which of these are used. Check the [SciPy documentation here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html) for further details on these. Alternatively for `least-squares` it represents the `gtol` parameter as found in the [SciPy documentation here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.least_squares.html)
 
+When using `least-squares` the faster Levenberg-Marquardt algorithm will be used when all `fitting_variables` have their default bounds of `-inf` and `+inf`. When any of these bounds take specific values, the Trust Region Reflective algorithm will be used instead.
+
 ### experiment
 
 | Keyword:              | `experiment` |

--- a/muspinsim/fitting.py
+++ b/muspinsim/fitting.py
@@ -46,7 +46,12 @@ class FittingRunner:
 
             self._xnames = tuple(sorted(variables.keys()))  # Order is important!
             self._x = np.array([variables[n].value for n in self._xnames])
-            self._xbounds = [variables[n].bounds for n in self._xnames]
+            self._xbounds = np.array([variables[n].bounds for n in self._xnames])
+
+            # Problem is constrained if the any of the bounds are not +/- inf
+            self._constrained = np.any(self._xbounds[:, 0] != -np.inf) or np.any(
+                self._xbounds[:, 1] != np.inf
+            )
 
             mpi.broadcast_object(self, ["_ytarg", "_x", "_xbounds", "_xnames"])
         else:
@@ -69,26 +74,29 @@ class FittingRunner:
             method = {
                 "nelder-mead": "nelder-mead",
                 "lbfgs": "L-BFGS-B",
-                "least-squares": "trf",
+                # To behave like curve_fit, use 'Levenberg-Marquardt' for
+                # unconstrained problems (as more efficient) and 'Trust
+                # Region Reflective' for constrained problems
+                "least-squares": "trf" if self._constrained else "lm",
             }[self._fitinfo["method"]]
 
             # SciPy minimise
             if self._fitinfo["method"] == "least-squares":
                 # Bounds used here are different to minimize, need all lower
                 # value and all upper values in separate arrays
+                bounds = (self._xbounds[:, 0], self._xbounds[:, 1])
 
                 # lbfgs uses gtol when using tol, so will do the same here
-                xbounds = np.array(self._xbounds)
                 self._sol = least_squares(
-                    self._targfun,
+                    self._targfun_residuals,
                     self._x,
-                    method="trf",
+                    method=method,
                     gtol=self._fitinfo["rtol"],
-                    bounds=(xbounds[:, 0], xbounds[:, 1]),
+                    bounds=bounds,
                 )
             else:
                 self._sol = minimize(
-                    self._targfun,
+                    self._targfun_minimise,
                     self._x,
                     method=method,
                     tol=self._fitinfo["rtol"],
@@ -128,9 +136,9 @@ class FittingRunner:
             self._runner = ExperimentRunner(self._input, variables=vardict)
             return self._runner.run()
 
-    def _targfun(self, x):
-
+    def _compute_result(self, x):
         self._x = x
+
         # Synchronize across nodes
         mpi.broadcast_object(self, ["_x", "_done"])
 
@@ -142,7 +150,30 @@ class FittingRunner:
         y = self._obtain_results(vardict)
 
         # Apply the results function
-        y = self._runner.apply_results_function(y, vardict)
+        return self._runner.apply_results_function(y, vardict)
+
+    def _targfun_residuals(self, x):
+        """Computes the residuals for the least-squares method for
+        a given set of input values
+
+        Returns one residual for each y value
+        """
+        y = self._compute_result(x)
+
+        if mpi.is_root:
+            # Compute residuals
+            err = y - self._ytarg
+            return err
+
+    def _targfun_minimise(self, x):
+        """Objective function for minimise methods
+
+        Returns a single float value representing the average absolute
+        difference between the target and found y values using the given
+        input values
+        """
+
+        y = self._compute_result(x)
 
         if mpi.is_root:
             # Compare with target data
@@ -177,7 +208,12 @@ class FittingRunner:
                 if not self._sol["success"]:
                     file.write(f"   Message: {self._sol['message']}\n")
 
+                if isinstance(self._sol["fun"], np.ndarray):
+                    # Compute average absolute error from the residuals when
+                    # using the residuals function
+                    self._sol["fun"] = np.average(np.abs(self._sol["fun"]))
                 file.write(f"Final absolute error <|f-f_targ|>: {self._sol['fun']}\n")
+
                 num_simulations = self._sol["nfev"]
                 if self._fitinfo["single_simulation"]:
                     num_simulations = 1

--- a/muspinsim/simconfig.py
+++ b/muspinsim/simconfig.py
@@ -186,7 +186,17 @@ class MuSpinConfig:
             # The x axis is overridden, whatever it is
             xname = list(self._x_range.keys())[0]
             self._constants.pop(xname, None)  # Just in case it was here
-            self._x_range[xname] = finfo["data"][:, 0]
+
+            # Special cases where loaded data will be a single value, but we
+            # actually need to load multiple
+            if xname in ["B", "intrinsic_B"]:
+                # Default to z axis (the same as in _validate_B below -
+                # the orientation is applied later)
+                self._x_range[xname] = np.array(
+                    [[0, 0, v] for v in finfo["data"][:, 0]]
+                )
+            else:
+                self._x_range[xname] = finfo["data"][:, 0]
             if xname == "t":
                 # Special case
                 self._time_N = len(self._x_range[xname])

--- a/muspinsim/tests/test_config.py
+++ b/muspinsim/tests/test_config.py
@@ -323,3 +323,46 @@ orientation
         itest = MuSpinInput(stest)
         with self.assertRaises(MuSpinConfigError):
             cfg = MuSpinConfig(itest.evaluate(A=0.0))
+
+    def test_fitting_magnetic_fields(self):
+        # Special tests for fitting tasks with magnetic fields as axes
+
+        stest = StringIO(
+            """
+y_axis
+    integral
+x_axis
+    field
+fitting_variables
+    A
+fitting_data
+    0   0.5
+    1   0.2
+"""
+        )
+
+        itest = MuSpinInput(stest)
+        cfg = MuSpinConfig(itest.evaluate(A=0.0))
+
+        self.assertTrue((np.array(cfg._x_range["B"]) == [[0, 0, 0], [0, 0, 1]]).all())
+
+        stest = StringIO(
+            """
+y_axis
+    integral
+x_axis
+    intrinsic_field
+fitting_variables
+    A
+fitting_data
+    0   0.5
+    1   0.2
+"""
+        )
+
+        itest = MuSpinInput(stest)
+        cfg = MuSpinConfig(itest.evaluate(A=0.0))
+
+        self.assertTrue(
+            (np.array(cfg._x_range["intrinsic_B"]) == [[0, 0, 0], [0, 0, 1]]).all()
+        )

--- a/muspinsim/tests/test_fitting.py
+++ b/muspinsim/tests/test_fitting.py
@@ -186,3 +186,35 @@ fitting_data
 
         self.assertAlmostEqual(sol.x[0], A, 2)
         self.assertAlmostEqual(sol.x[1], B, 2)
+
+        # Try fitting a basic ALC experiment
+        s1 = StringIO(
+            """
+spins
+    mu e
+hyperfine 1
+    580 5   10
+    5   580 9
+    10  9   580
+orientation
+    zcw(10)
+field
+    range(1.8, 2.6, 2)
+experiment
+    alc
+results_function
+    A*y
+fitting_variables
+    A 0.5
+fitting_data
+    1.8 1
+    2.6 1
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+
+        sol = f1.run()
+
+        self.assertAlmostEqual(sol.x[0], 2, 1)

--- a/muspinsim/tests/test_fitting.py
+++ b/muspinsim/tests/test_fitting.py
@@ -26,8 +26,8 @@ fitting_data
 
         self.assertEqual(f1._xnames, ("A", "B"))
         self.assertTrue((f1._x == [0, 1]).all())
-        self.assertEqual(f1._xbounds[0], (-np.inf, np.inf))
-        self.assertEqual(f1._xbounds[1], (0.0, 2.0))
+        self.assertTrue((f1._xbounds[0] == [-np.inf, np.inf]).all())
+        self.assertTrue((f1._xbounds[1] == [0.0, 2.0]).all())
 
     def test_fitrun(self):
 
@@ -82,8 +82,29 @@ dissipation 1
 
         self.assertAlmostEqual(sol.x[0], g, 3)
 
-        # Try fitting a very basic exponential decay
-        # with least_squares
+        # Try fitting a very basic exponential decay with least_squares
+        # with an unconstrained problem and no initial guess
+        s1 = StringIO(
+            f"""
+spins
+    mu
+fitting_method
+    least-squares
+fitting_variables
+    g
+fitting_data
+{dblock}
+dissipation 1
+    g
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+        self.assertFalse(f1._constrained)
+
+        # Try fitting a very basic exponential decay with least_squares
+        # with an unconstrained problem and an initial guess
         s1 = StringIO(
             f"""
 spins
@@ -101,6 +122,32 @@ dissipation 1
 
         i1 = MuSpinInput(s1)
         f1 = FittingRunner(i1)
+        self.assertFalse(f1._constrained)
+
+        sol = f1.run()
+
+        self.assertAlmostEqual(sol.x[0], g, 2)
+
+        # Try fitting a very basic exponential decay
+        # with least_squares with a constrained problem
+        s1 = StringIO(
+            f"""
+spins
+    mu
+fitting_method
+    least-squares
+fitting_variables
+    g   0.5 0 5
+fitting_data
+{dblock}
+dissipation 1
+    g
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+        self.assertTrue(f1._constrained)
 
         sol = f1.run()
 
@@ -162,7 +209,35 @@ fitting_data
         self.assertAlmostEqual(sol.x[0], A, 1)
         self.assertAlmostEqual(sol.x[1], B, 1)
 
-        # Try fitting a basic cosine with least_squares
+        # Try fitting a basic cosine with least_squares - with unconstrained
+        # bounds and no initial guess
+        s1 = StringIO(
+            f"""
+spins
+    mu
+results_function
+    A*cos(x)+B
+fitting_method
+    least-squares
+fitting_variables
+    A
+    B
+fitting_data
+{dblock}
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+        self.assertFalse(f1._constrained)
+
+        sol = f1.run()
+
+        self.assertAlmostEqual(sol.x[0], A, 2)
+        self.assertAlmostEqual(sol.x[1], B, 2)
+
+        # Try fitting a basic cosine with least_squares - with unconstrained
+        # bounds and an initial guess
         s1 = StringIO(
             f"""
 spins
@@ -181,6 +256,34 @@ fitting_data
 
         i1 = MuSpinInput(s1)
         f1 = FittingRunner(i1)
+        self.assertFalse(f1._constrained)
+
+        sol = f1.run()
+
+        self.assertAlmostEqual(sol.x[0], A, 2)
+        self.assertAlmostEqual(sol.x[1], B, 2)
+
+        # Try fitting a basic cosine with least_squares - with constrained
+        # bounds
+        s1 = StringIO(
+            f"""
+spins
+    mu
+results_function
+    A*cos(x)+B
+fitting_method
+    least-squares
+fitting_variables
+    A 0.5 0 10
+    B 0.5 0 10
+fitting_data
+{dblock}
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+        self.assertTrue(f1._constrained)
 
         sol = f1.run()
 

--- a/muspinsim/version.py
+++ b/muspinsim/version.py
@@ -2,4 +2,4 @@
 
 Version of the package. Kept separated to allow for import from setup.py"""
 
-__version__ = "2.2.1"
+__version__ = "2.3.0"


### PR DESCRIPTION
- Fixes an issue found while attempting to fit for an ALC experiment. It turned out the overriding behaviour of the x values for any fitting_data caused the fitting to fail as the magnetic field values were not converted to 3D vectors prior to rotating them.
- Also least-squares should really have been using an array of residuals, which is different to the minimise function which takes a single float value as input. This PR also fixes that.
- I also noticed curve_fit uses the 'lm' method of least-squares when the problem is unconstrained. This method is much faster and has less weirdness than the 'trf' method that supports constrained systems, so I also automatically switch between the two in this PR and updated the docs to reflect this.
- Finally single_simulation in fitting added with #78 was not broadcast correctly, causing errors when it was false and running with mpirun

Will release v2.3.0 once this is merged.

Closes #81