### PR TITLE
Fix macOS OMP tests action and implement codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+branch = True
+source = muspinsim
+omit = muspinsim/tests/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
           echo "CC=$(brew --prefix llvm@15)/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> "$GITHUB_ENV"
           brew info libomp
-          ls -l /usr/local/Cellar/libomp/16.0.5
+          ls -l /usr/local/Cellar/libomp
           ls -l /usr/local/opt/libomp
           brew link libomp --force
           ls -l /usr/local/opt/libomp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,10 @@ jobs:
           echo "CC=$(brew --prefix llvm@15)/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> "$GITHUB_ENV"
           brew info libomp
-          printenv LD_LIBRARY_PATH
+          echo "$LD_LIBRARY_PATH"
+          export LDFLAGS="-L/usr/local/opt/libomp/lib"
+          export CPPFLAGS="-I/usr/local/opt/libomp/include"
+          #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/your/custom/path/
         fi
       shell: bash
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
           echo "CC=$(brew --prefix llvm@15)/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> "$GITHUB_ENV"
           brew info libomp
-          tree /usr/local/Cellar/libomp/16.0.5
+          ls -l /usr/local/Cellar/libomp/16.0.5
           ls -l /usr/local/opt/libomp
           brew link libomp --force
           ls -l /usr/local/opt/libomp
@@ -109,7 +109,7 @@ jobs:
           echo $CPPFLAGS
           export LDFLAGS="-L/usr/local/opt/libomp/lib"
           export CPPFLAGS="-I/usr/local/opt/libomp/include"
-          #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/your/custom/path/
+          export LD_LIBRARY_PATH="-L/usr/local/opt/libomp/lib"
           echo $LD_LIBRARY_PATH
           echo $LDFLAGS
           echo $CPPFLAGS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,14 +108,18 @@ jobs:
           echo $LDFLAGS
           echo $CPPFLAGS
           echo $LIBRARY_PATH
-          export LDFLAGS="-L/usr/local/opt/libomp/lib"
-          export CPPFLAGS="-I/usr/local/opt/libomp/include"
-          export LD_LIBRARY_PATH="-L/usr/local/opt/libomp/lib"
-          export LD_LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/libomp/lib"
-          echo $LD_LIBRARY_PATH
-          echo $LDFLAGS
-          echo $CPPFLAGS
-          echo $LIBRARY_PATH
+          echo "LD_LIBRARY_PATH=-L/usr/local/opt/libomp/lib" >> "$GITHUB_ENV"
+          echo "LDFLAGS=-L/usr/local/opt/libomp/lib" >> "$GITHUB_ENV"
+          echo "CPPFLAGS=-I/usr/local/opt/libomp/include" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=/usr/local/opt/libomp/lib" >> "$GITHUB_ENV"
+          #export LDFLAGS="-L/usr/local/opt/libomp/lib"
+          #export CPPFLAGS="-I/usr/local/opt/libomp/include"
+          #export LD_LIBRARY_PATH="-L/usr/local/opt/libomp/lib"
+          #export LD_LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/libomp/lib"
+          #echo $LD_LIBRARY_PATH
+          #echo $LDFLAGS
+          #echo $CPPFLAGS
+          #echo $LIBRARY_PATH
         fi
       shell: bash
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,32 +94,16 @@ jobs:
     # Default compiler on macOS doesn't support OpenMP, so force the usage
     # of homebrew's llvm see
     # https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md
+    # Even when installed, clang++ may not be able to find the OMP library when installed
+    # To resolve this, export the environment variables suggested by brew to $GITHUB_ENV
     - name: Add optional environment variables
       run: |
         if [ "$RUNNER_OS" == 'macOS' ]; then
           echo "CC=$(brew --prefix llvm@15)/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> "$GITHUB_ENV"
           brew info libomp
-          ls -l /usr/local/Cellar/libomp/16.0.5/*
-          ls -l /usr/local/opt/libomp
-          brew link libomp --force
-          ls -l /usr/local/opt/libomp
-          echo $LD_LIBRARY_PATH
-          echo $LDFLAGS
-          echo $CPPFLAGS
-          echo $LIBRARY_PATH
-          echo "LD_LIBRARY_PATH=-L/usr/local/opt/libomp/lib" >> "$GITHUB_ENV"
           echo "LDFLAGS=-L/usr/local/opt/libomp/lib" >> "$GITHUB_ENV"
           echo "CPPFLAGS=-I/usr/local/opt/libomp/include" >> "$GITHUB_ENV"
-          echo "LIBRARY_PATH=/usr/local/opt/libomp/lib" >> "$GITHUB_ENV"
-          #export LDFLAGS="-L/usr/local/opt/libomp/lib"
-          #export CPPFLAGS="-I/usr/local/opt/libomp/include"
-          #export LD_LIBRARY_PATH="-L/usr/local/opt/libomp/lib"
-          #export LD_LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/libomp/lib"
-          #echo $LD_LIBRARY_PATH
-          #echo $LDFLAGS
-          #echo $CPPFLAGS
-          #echo $LIBRARY_PATH
         fi
       shell: bash
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,8 +100,12 @@ jobs:
           echo "CC=$(brew --prefix llvm@15)/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> "$GITHUB_ENV"
           brew info libomp
-          brew link libomp
+          ls /usr/local/Cellar/libomp/16.0.5
+          ls /usr/local/opt
+          brew link libomp --force
           echo $LD_LIBRARY_PATH
+          echo $LDFLAGS
+          echo $CPPFLAGS
           export LDFLAGS="-L/usr/local/opt/libomp/lib"
           export CPPFLAGS="-I/usr/local/opt/libomp/include"
           #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/your/custom/path/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Install package
       env:
         MUSPINSIM_WITH_OPENMP: 1
-      run: pip install -e .
+      run: pip install .
     - name: Test with pytest
       run: pytest --cov --cov-report xml --pyargs muspinsim
     - name: Upload to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,13 +99,14 @@ jobs:
         if [ "$RUNNER_OS" == 'macOS' ]; then
           echo "CC=$(brew --prefix llvm@15)/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> "$GITHUB_ENV"
+          brew install libomp
         fi
       shell: bash
 
     - name: Install package
       env:
         MUSPINSIM_WITH_OPENMP: 1
-      run: pip install .
+      run: pip install -e .
     - name: Test with pytest
       run: pytest --cov --cov-report xml --pyargs muspinsim
     - name: Upload to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,9 @@ jobs:
     - name: Install package
       env:
         MUSPINSIM_WITH_OPENMP: 1
-      run: pip install .
+      run: pip install -e .
     - name: Test with pytest
-      run: pytest --pyargs muspinsim
+      run: pytest --cov --cov-report xml --pyargs muspinsim
+    - name: Upload to Codecov
+      if: matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.10"]
-        os: [ubuntu-latest, macOS-11, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v3
@@ -75,7 +75,7 @@ jobs:
         # macOS-11 pinned here due to usage of $(brew --prefix llvm@15)
         # macOS-12 will become macOS-latest in the near future but
         # is currently still unstable
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-11, windows-latest]
 
     steps:
     - uses: actions/checkout@v3
@@ -100,19 +100,22 @@ jobs:
           echo "CC=$(brew --prefix llvm@15)/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> "$GITHUB_ENV"
           brew info libomp
-          ls -l /usr/local/Cellar/libomp
+          ls -l /usr/local/Cellar/libomp/16.0.5/*
           ls -l /usr/local/opt/libomp
           brew link libomp --force
           ls -l /usr/local/opt/libomp
           echo $LD_LIBRARY_PATH
           echo $LDFLAGS
           echo $CPPFLAGS
+          echo $LIBRARY_PATH
           export LDFLAGS="-L/usr/local/opt/libomp/lib"
           export CPPFLAGS="-I/usr/local/opt/libomp/include"
           export LD_LIBRARY_PATH="-L/usr/local/opt/libomp/lib"
+          export LD_LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/libomp/lib"
           echo $LD_LIBRARY_PATH
           echo $LDFLAGS
           echo $CPPFLAGS
+          echo $LIBRARY_PATH
         fi
       shell: bash
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,8 @@ jobs:
           echo "CC=$(brew --prefix llvm@15)/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> "$GITHUB_ENV"
           brew info libomp
-          echo "$LD_LIBRARY_PATH"
+          brew link libomp
+          echo $LD_LIBRARY_PATH
           export LDFLAGS="-L/usr/local/opt/libomp/lib"
           export CPPFLAGS="-I/usr/local/opt/libomp/include"
           #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/your/custom/path/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.10"]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-11, windows-latest]
 
     steps:
     - uses: actions/checkout@v3
@@ -100,22 +100,33 @@ jobs:
           echo "CC=$(brew --prefix llvm@15)/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> "$GITHUB_ENV"
           brew info libomp
-          ls /usr/local/Cellar/libomp/16.0.5
-          ls /usr/local/opt
+          tree /usr/local/Cellar/libomp/16.0.5
+          ls -l /usr/local/opt/libomp
           brew link libomp --force
+          ls -l /usr/local/opt/libomp
           echo $LD_LIBRARY_PATH
           echo $LDFLAGS
           echo $CPPFLAGS
           export LDFLAGS="-L/usr/local/opt/libomp/lib"
           export CPPFLAGS="-I/usr/local/opt/libomp/include"
           #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/your/custom/path/
+          echo $LD_LIBRARY_PATH
+          echo $LDFLAGS
+          echo $CPPFLAGS
         fi
       shell: bash
 
+    - name: Install package with -e
+      env:
+        MUSPINSIM_WITH_OPENMP: 1
+      if: matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+      run: pip install -e .
     - name: Install package
       env:
         MUSPINSIM_WITH_OPENMP: 1
-      run: pip install -e .
+      if: matrix.python-version != '3.10' || matrix.os != 'ubuntu-latest'
+      run: pip install .
+
     - name: Test with pytest
       run: pytest --cov --cov-report xml --pyargs muspinsim
     - name: Upload to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
         # macOS-11 pinned here due to usage of $(brew --prefix llvm@15)
         # macOS-12 will become macOS-latest in the near future but
         # is currently still unstable
-        os: [ubuntu-latest, macOS-11, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v3
@@ -99,7 +99,8 @@ jobs:
         if [ "$RUNNER_OS" == 'macOS' ]; then
           echo "CC=$(brew --prefix llvm@15)/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> "$GITHUB_ENV"
-          brew install libomp
+          brew info libomp
+          printenv LD_LIBRARY_PATH
         fi
       shell: bash
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://github.com/muon-spectroscopy-computational-project/muspinsim/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/muon-spectroscopy-computational-project/muspinsim/actions/workflows/test.yml)
+[![Codecov](https://codecov.io/gh/muon-spectroscopy-computational-project/muspinsim/branch/main/graph/badge.svg)](https://codecov.io/gh/muon-spectroscopy-computational-project/muspinsim)
+
 # muspinsim
 
 MuSpinSim is a Python software meant to simulate muon spectroscopy experiments. In particular, it simulates the spin dynamics of a system of a muon plus other spins, namely electrons and atomic nuclei. It can simulate various common experimental setups and account for hyperfine, dipolar and quadrupolar couplings. It is also able to fit its simulations

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,6 +33,7 @@ pycodestyle==2.10.0
 pyflakes==3.0.1
 pyparsing==3.0.9
 pytest==7.2.1
+pytest-cov==4.1.0
 python-dateutil==2.8.2
 PyYAML==6.0
 qutip==4.7.1


### PR DESCRIPTION
Implements codecov for our GHA workflows, in the same manner as PyMuonSuite.

Also fixes the failing GHA for macOS OMP tests, by writing the libomp path to `$GITHUB_ENV`. This is currently causing failures on all branches/PRs.