### PR TITLE
Overwrite x_axis only during fitting #77

### DIFF
--- a/docs/docs/input.md
+++ b/docs/docs/input.md
@@ -201,7 +201,7 @@ x_axis
     field
 ```
 
-Which range to use as the X axis of the simulation's output files. Must be another keyword that accepts a range, and the given keyword *must be specified as a range* in this input file. When fitting, this is also assumed to be the X axis of the data to fit, and the range specified for this keyword is overridden by the fitting data. By default it's `time`. 
+Which range to use as the X axis of the simulation's output files. Must be another keyword that accepts a range, and the given keyword *must be specified as a range* in this input file. When fitting, if x_axis is specified or the range for the default range `time` is set, then the user provided X values will not be used to perform the fit (as the fitting data's X values are used to optimise the `fitting_variables`). They will, however, be used to perform a final evaluation when writing the .dat file. This enables the fit to use all the available data, whilst also allowing the user to evaluate data for a particular region of interest, or at a different precision. If the range provided does not overlap with the experimental data, then the user will be warned that the they are extrapolating the result of the fit. By default it's `time`. 
 
 ### y_axis
 

--- a/muspinsim/__main__.py
+++ b/muspinsim/__main__.py
@@ -140,7 +140,7 @@ def main(use_mpi=False):
             runner.config.save_output(name=None, path=out_path)
     else:
         fitter = FittingRunner(in_file)
-        fitter.run(name=None, path=out_path)
+        fitter.run()
 
         if mpi.is_root:
             rep_dname = inp_dir
@@ -157,6 +157,7 @@ def main(use_mpi=False):
                     rep_dname = inp_dir
 
             fitter.write_report(fname=rep_fname, path=rep_dname)
+            fitter.write_data(name=None, path=out_path)
 
     if mpi.is_root:
         t_end = datetime.now()

--- a/muspinsim/experiment.py
+++ b/muspinsim/experiment.py
@@ -24,7 +24,12 @@ class ExperimentRunner:
     provide caching for any quantities that might not need to be recalculated
     between successive snapshots."""
 
-    def __init__(self, in_file: MuSpinInput, variables: dict = None):
+    def __init__(
+        self,
+        in_file: MuSpinInput,
+        variables: dict = None,
+        use_experimental_x_axis: bool = True,
+    ):
         """Set up an experiment as defined by a MuSpinInput object
 
         Prepare a set of calculations (for multiple files and averages) as
@@ -39,6 +44,11 @@ class ExperimentRunner:
                                 running a fitting calculation, in which case
                                 results_function will not be applied when 'run' is
                                 called as it is already applied by the FittingRunner.
+            use_experimental_x_axis -- Only used for fittings. If True, then any x_axis
+                                       specified by the user will be overwritten (this
+                                       should be the case forfitting, but not for final
+                                       evaluation where the user may want a different
+                                       range), Default is True.
         """
         # Fix W0102:dangerous-default-value
         if variables is None:
@@ -52,7 +62,10 @@ class ExperimentRunner:
             # values for simulation configurations. These are then broadcast
             # across all nodes, each of which runs its own slice of them, and
             # finally gathered back together
-            config = MuSpinConfig(in_file.evaluate(**variables))
+            config = MuSpinConfig(
+                params=in_file.evaluate(**variables),
+                use_experimental_x_axis=use_experimental_x_axis,
+            )
         else:
             config = MuSpinConfig()
 
@@ -263,7 +276,6 @@ class ExperimentRunner:
             )
 
         if self._dops is None:
-
             # Create a copy of the system
             sys = self._system.clone()
 
@@ -298,7 +310,6 @@ class ExperimentRunner:
 
             self._dops = []
             for i, a in self._config.dissipation_terms.items():
-
                 op_x = sparse_sum(self._single_spinops[i, :, None] * x[:, None])
                 op_y = sparse_sum(self._single_spinops[i, :, None] * y[:, None])
                 op_p = SpinOperator(op_x + 1.0j * op_y, dim=self.system.dimension)

--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from muspinsim.input.keyword import (
     InputKeywords,
+    KWXAxis,
     MuSpinEvaluateKeyword,
     MuSpinCouplingKeyword,
 )
@@ -66,7 +67,6 @@ def _make_blocks(file_stream):
     indent = None
 
     for i, l in enumerate(lines):
-
         # Remove any comments
         l = l.split("#", 1)[0]
 
@@ -119,10 +119,10 @@ class MuSpinInput:
             "function": None,
             # When true indicates all fitting can be done after the simulation
             "single_simulation": True,
+            "evaluate_x_axis": False,
         }
 
         if file_stream is not None:
-
             raw_blocks, block_line_nums = _make_blocks(file_stream)
 
             # if we find errors when parsing fitting variables, we post an error
@@ -228,7 +228,6 @@ class MuSpinInput:
         result = {"couplings": {}, "fitting_info": self.fitting_info}
 
         for name, KWClass in InputKeywords.items():
-
             if issubclass(KWClass, MuSpinCouplingKeyword):
                 if name in self._keywords:
                     for kwid, kw in self._keywords[name].items():
@@ -255,6 +254,13 @@ class MuSpinInput:
                         result[name] = KWClass(variables=variables)
                 elif name in self._keywords:
                     kw = self._keywords[name]
+                    print(kw.name)
+                    if kw.name == "x_axis" or kw.name == KWXAxis.default:
+                        # We perform the fitting on the experimental data, but
+                        # if the user has tried to specify x_axis, we should
+                        # evaluate on that for the output .dat file
+                        result["fitting_info"]["evaluate_x_axis"] = True
+
                     v = variables if issubclass(KWClass, MuSpinEvaluateKeyword) else {}
                     val = kw.evaluate(**v)
 

--- a/muspinsim/input/input.py
+++ b/muspinsim/input/input.py
@@ -254,7 +254,6 @@ class MuSpinInput:
                         result[name] = KWClass(variables=variables)
                 elif name in self._keywords:
                     kw = self._keywords[name]
-                    print(kw.name)
                     if kw.name == "x_axis" or kw.name == KWXAxis.default:
                         # We perform the fitting on the experimental data, but
                         # if the user has tried to specify x_axis, we should

--- a/muspinsim/simconfig.py
+++ b/muspinsim/simconfig.py
@@ -183,10 +183,10 @@ class MuSpinConfig:
             if len(self._file_ranges) > 0:
                 raise MuSpinConfigError("Can not have file ranges when fitting")
 
-            xname = list(self._x_range.keys())[0]
+            xname, xvalue = list(self._x_range.items())[0]
             self._constants.pop(xname, None)  # Just in case it was here
 
-            if self._x_range[xname] is None:
+            if xvalue is None:
                 # Can happen when xname keyword is a single value, and so not assigned
                 # In this case, we must use the experimental data, as that's the only
                 # x_range we have
@@ -211,8 +211,8 @@ class MuSpinConfig:
                         "specified 'x_axis' will only be used to generate final "
                         ".dat file"
                     )
-                    below_min = self._x_range[xname] < experimental_x_range[0]
-                    above_max = self._x_range[xname] > experimental_x_range[-1]
+                    below_min = xvalue < experimental_x_range[0]
+                    above_max = xvalue > experimental_x_range[-1]
                     if np.all(above_max) or np.all(below_min):
                         logging.warning(
                             "All points on specified 'x_axis' are outside the "

--- a/muspinsim/simconfig.py
+++ b/muspinsim/simconfig.py
@@ -186,6 +186,13 @@ class MuSpinConfig:
             xname = list(self._x_range.keys())[0]
             self._constants.pop(xname, None)  # Just in case it was here
 
+            if self._x_range[xname] is None:
+                # Can happen when xname keyword is a single value, and so not assigned
+                # In this case, we must use the experimental data, as that's the only
+                # x_range we have
+                use_experimental_x_axis = True
+                finfo["evaluate_x_axis"] = False
+
             if use_experimental_x_axis:
                 # Special cases where loaded data will be a single value, but we
                 # actually need to load multiple

--- a/muspinsim/tests/test_fitting.py
+++ b/muspinsim/tests/test_fitting.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import unittest
 import numpy as np
 from io import StringIO
@@ -6,9 +8,14 @@ from muspinsim.input import MuSpinInput
 from muspinsim.fitting import FittingRunner
 
 
+EXPECTED_LOG = (
+    "INFO:root:Fitting will be performed on experimental data-points, "
+    "specified 'x_axis' will only be used to generate final .dat file"
+)
+
+
 class TestFitting(unittest.TestCase):
     def test_fitset(self):
-
         s1 = StringIO(
             """
 fitting_variables
@@ -30,7 +37,6 @@ fitting_data
         self.assertTrue((f1._xbounds[1] == [0.0, 2.0]).all())
 
     def test_fitrun(self):
-
         # Try fitting a very basic exponential decay
         data = np.zeros((100, 3))
         data[:, 0] = np.linspace(0, 10.0, len(data))
@@ -54,7 +60,9 @@ dissipation 1
         i1 = MuSpinInput(s1)
         f1 = FittingRunner(i1)
 
-        sol = f1.run()
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertNotIn(EXPECTED_LOG, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], g, 3)
 
@@ -78,7 +86,9 @@ dissipation 1
         i1 = MuSpinInput(s1)
         f1 = FittingRunner(i1)
 
-        sol = f1.run()
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertNotIn(EXPECTED_LOG, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], g, 3)
 
@@ -124,7 +134,9 @@ dissipation 1
         f1 = FittingRunner(i1)
         self.assertFalse(f1._constrained)
 
-        sol = f1.run()
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertNotIn(EXPECTED_LOG, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], g, 2)
 
@@ -149,12 +161,13 @@ dissipation 1
         f1 = FittingRunner(i1)
         self.assertTrue(f1._constrained)
 
-        sol = f1.run()
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertNotIn(EXPECTED_LOG, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], g, 2)
 
     def test_fit_results_function(self):
-
         # Try fitting a basic cosine function
         A = 2
         B = 1
@@ -179,7 +192,9 @@ fitting_data
         i1 = MuSpinInput(s1)
         f1 = FittingRunner(i1)
 
-        sol = f1.run()
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertNotIn(EXPECTED_LOG, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], A, 3)
         self.assertAlmostEqual(sol.x[1], B, 3)
@@ -204,7 +219,9 @@ fitting_data
         i1 = MuSpinInput(s1)
         f1 = FittingRunner(i1)
 
-        sol = f1.run()
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertNotIn(EXPECTED_LOG, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], A, 1)
         self.assertAlmostEqual(sol.x[1], B, 1)
@@ -231,7 +248,9 @@ fitting_data
         f1 = FittingRunner(i1)
         self.assertFalse(f1._constrained)
 
-        sol = f1.run()
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertNotIn(EXPECTED_LOG, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], A, 2)
         self.assertAlmostEqual(sol.x[1], B, 2)
@@ -258,7 +277,9 @@ fitting_data
         f1 = FittingRunner(i1)
         self.assertFalse(f1._constrained)
 
-        sol = f1.run()
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertNotIn(EXPECTED_LOG, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], A, 2)
         self.assertAlmostEqual(sol.x[1], B, 2)
@@ -285,7 +306,9 @@ fitting_data
         f1 = FittingRunner(i1)
         self.assertTrue(f1._constrained)
 
-        sol = f1.run()
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertNotIn(EXPECTED_LOG, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], A, 2)
         self.assertAlmostEqual(sol.x[1], B, 2)
@@ -318,6 +341,91 @@ fitting_data
         i1 = MuSpinInput(s1)
         f1 = FittingRunner(i1)
 
-        sol = f1.run()
+        # Expect the warning, as we have specified field which is taken as
+        # x_axis for an alc experiment
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertIn(EXPECTED_LOG, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], 2, 1)
+
+    def test_fit_x_axis(self):
+        # Test that if an x_axis is provided, we evaluate the results on that
+        # whilst fitting on the experimental data (this will use the default
+        # range for time, which has 101 elements)
+        data = np.zeros((100, 3))
+        data[:, 0] = np.linspace(0, 10.0, len(data))
+        g = 0.2
+        data[:, 1] = 0.5 * np.exp(-g * data[:, 0])
+        dblock = "\n".join(["\t{0} {1}".format(*d) for d in data])
+
+        s1 = StringIO(
+            f"""
+spins
+    mu
+fitting_variables
+    g   0.5
+fitting_data
+{dblock}
+dissipation 1
+    g
+x_axis
+    time
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertIn(EXPECTED_LOG, context_manager.output)
+
+        self.assertAlmostEqual(sol.x[0], g, 3)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            f1.write_data(name="test", path=tmp_dir)
+            with open(os.path.join(tmp_dir, "test.dat")) as f:
+                lines = f.readlines()
+                print(*lines)
+                self.assertEqual(len(lines), 105)
+
+    def test_fit_time(self):
+        # Test that if an time is altered is provided, we evaluate the results
+        # on that whilst fitting on the experimental data
+        data = np.zeros((100, 3))
+        data[:, 0] = np.linspace(0, 10.0, len(data))
+        g = 0.2
+        data[:, 1] = 0.5 * np.exp(-g * data[:, 0])
+        dblock = "\n".join(["\t{0} {1}".format(*d) for d in data])
+
+        s1 = StringIO(
+            f"""
+spins
+    mu
+fitting_variables
+    g   0.5
+fitting_data
+{dblock}
+dissipation 1
+    g
+time
+    range(0, 1, 11)
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertIn(EXPECTED_LOG, context_manager.output)
+
+        self.assertAlmostEqual(sol.x[0], g, 3)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            f1.write_data(name="test", path=tmp_dir)
+            with open(os.path.join(tmp_dir, "test.dat")) as f:
+                lines = f.readlines()
+                print(*lines)
+                self.assertEqual(len(lines), 15)

--- a/muspinsim/tests/test_fitting.py
+++ b/muspinsim/tests/test_fitting.py
@@ -8,9 +8,17 @@ from muspinsim.input import MuSpinInput
 from muspinsim.fitting import FittingRunner
 
 
-EXPECTED_LOG = (
+OVERWRITE_LOG = (
     "INFO:root:Fitting will be performed on experimental data-points, "
     "specified 'x_axis' will only be used to generate final .dat file"
+)
+EXTRAPOLATION_INFO = (
+    "INFO:root:Some points on specified 'x_axis' are outside the experimental range, "
+    "fitted parameters may not be appropriate for extrapolation"
+)
+EXTRAPOLATION_WARNING = (
+    "WARNING:root:All points on specified 'x_axis' are outside the experimental range, "
+    "fitted parameters may not be appropriate for extrapolation"
 )
 
 
@@ -62,7 +70,9 @@ dissipation 1
 
         with self.assertLogs() as context_manager:
             sol = f1.run()
-            self.assertNotIn(EXPECTED_LOG, context_manager.output)
+            self.assertNotIn(OVERWRITE_LOG, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_WARNING, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], g, 3)
 
@@ -88,7 +98,9 @@ dissipation 1
 
         with self.assertLogs() as context_manager:
             sol = f1.run()
-            self.assertNotIn(EXPECTED_LOG, context_manager.output)
+            self.assertNotIn(OVERWRITE_LOG, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_WARNING, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], g, 3)
 
@@ -136,7 +148,9 @@ dissipation 1
 
         with self.assertLogs() as context_manager:
             sol = f1.run()
-            self.assertNotIn(EXPECTED_LOG, context_manager.output)
+            self.assertNotIn(OVERWRITE_LOG, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_WARNING, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], g, 2)
 
@@ -163,7 +177,9 @@ dissipation 1
 
         with self.assertLogs() as context_manager:
             sol = f1.run()
-            self.assertNotIn(EXPECTED_LOG, context_manager.output)
+            self.assertNotIn(OVERWRITE_LOG, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_WARNING, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], g, 2)
 
@@ -194,7 +210,9 @@ fitting_data
 
         with self.assertLogs() as context_manager:
             sol = f1.run()
-            self.assertNotIn(EXPECTED_LOG, context_manager.output)
+            self.assertNotIn(OVERWRITE_LOG, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_WARNING, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], A, 3)
         self.assertAlmostEqual(sol.x[1], B, 3)
@@ -221,7 +239,9 @@ fitting_data
 
         with self.assertLogs() as context_manager:
             sol = f1.run()
-            self.assertNotIn(EXPECTED_LOG, context_manager.output)
+            self.assertNotIn(OVERWRITE_LOG, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_WARNING, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], A, 1)
         self.assertAlmostEqual(sol.x[1], B, 1)
@@ -250,7 +270,9 @@ fitting_data
 
         with self.assertLogs() as context_manager:
             sol = f1.run()
-            self.assertNotIn(EXPECTED_LOG, context_manager.output)
+            self.assertNotIn(OVERWRITE_LOG, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_WARNING, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], A, 2)
         self.assertAlmostEqual(sol.x[1], B, 2)
@@ -279,7 +301,9 @@ fitting_data
 
         with self.assertLogs() as context_manager:
             sol = f1.run()
-            self.assertNotIn(EXPECTED_LOG, context_manager.output)
+            self.assertNotIn(OVERWRITE_LOG, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_WARNING, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], A, 2)
         self.assertAlmostEqual(sol.x[1], B, 2)
@@ -308,7 +332,9 @@ fitting_data
 
         with self.assertLogs() as context_manager:
             sol = f1.run()
-            self.assertNotIn(EXPECTED_LOG, context_manager.output)
+            self.assertNotIn(OVERWRITE_LOG, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_WARNING, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], A, 2)
         self.assertAlmostEqual(sol.x[1], B, 2)
@@ -345,7 +371,9 @@ fitting_data
         # x_axis for an alc experiment
         with self.assertLogs() as context_manager:
             sol = f1.run()
-            self.assertIn(EXPECTED_LOG, context_manager.output)
+            self.assertIn(OVERWRITE_LOG, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_WARNING, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], 2, 1)
 
@@ -379,7 +407,9 @@ x_axis
 
         with self.assertLogs() as context_manager:
             sol = f1.run()
-            self.assertIn(EXPECTED_LOG, context_manager.output)
+            self.assertIn(OVERWRITE_LOG, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_WARNING, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], g, 3)
 
@@ -387,7 +417,6 @@ x_axis
             f1.write_data(name="test", path=tmp_dir)
             with open(os.path.join(tmp_dir, "test.dat")) as f:
                 lines = f.readlines()
-                print(*lines)
                 self.assertEqual(len(lines), 105)
 
     def test_fit_time(self):
@@ -410,7 +439,7 @@ fitting_data
 dissipation 1
     g
 time
-    range(0, 1, 11)
+    range(9, 11, 11)
 """
         )
 
@@ -419,7 +448,9 @@ time
 
         with self.assertLogs() as context_manager:
             sol = f1.run()
-            self.assertIn(EXPECTED_LOG, context_manager.output)
+            self.assertIn(OVERWRITE_LOG, context_manager.output)
+            self.assertIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_WARNING, context_manager.output)
 
         self.assertAlmostEqual(sol.x[0], g, 3)
 
@@ -427,5 +458,46 @@ time
             f1.write_data(name="test", path=tmp_dir)
             with open(os.path.join(tmp_dir, "test.dat")) as f:
                 lines = f.readlines()
-                print(*lines)
+                self.assertEqual(len(lines), 15)
+
+    def test_fit_extrapolate_all(self):
+        # Test that if an time is altered is provided that does not overlap with
+        # experiment, we evaluate the results on that whilst fitting on the
+        # experimental data and warn the user
+        data = np.zeros((100, 3))
+        data[:, 0] = np.linspace(0, 10.0, len(data))
+        g = 0.2
+        data[:, 1] = 0.5 * np.exp(-g * data[:, 0])
+        dblock = "\n".join(["\t{0} {1}".format(*d) for d in data])
+
+        s1 = StringIO(
+            f"""
+spins
+    mu
+fitting_variables
+    g   0.5
+fitting_data
+{dblock}
+dissipation 1
+    g
+time
+    range(11, 12, 11)
+"""
+        )
+
+        i1 = MuSpinInput(s1)
+        f1 = FittingRunner(i1)
+
+        with self.assertLogs() as context_manager:
+            sol = f1.run()
+            self.assertIn(OVERWRITE_LOG, context_manager.output)
+            self.assertNotIn(EXTRAPOLATION_INFO, context_manager.output)
+            self.assertIn(EXTRAPOLATION_WARNING, context_manager.output)
+
+        self.assertAlmostEqual(sol.x[0], g, 3)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            f1.write_data(name="test", path=tmp_dir)
+            with open(os.path.join(tmp_dir, "test.dat")) as f:
+                lines = f.readlines()
                 self.assertEqual(len(lines), 15)


### PR DESCRIPTION
Adds handling for `x_axis` and `x_axis_values` for fitting experiments. The WARNING for overwriting values has been downgraded to INFO, and will only be printed when the x_axis is set by the user (this checks the value for `x_axis` and also if the default value of time is altered without explicitly changing `x_axis`). If no values given, we use the experimental data for the final evaluation of the function, and saving the .dat file.

If however the user specifies values, then these will be used only for the final .dat evaluation.

## Justification
Considered interpolation/overlapping of ranges provided by the user, but decided that this was not the right approach as the experimental data contains all our information, and we will either be upscaling (implying a precision we do not possess) or downscaling (discarding information prior to the fit). Neither of these is a good. Instead, we should use (all) the information we have for the fit, which defines our variables - then if the user wants to evaluate this on a range which differs from the experimental range, that is perfectly acceptable - and would be no different from if they just started a new experiment with the values that came out of the fit and a new x_axis. This approach is also a lot simpler than having to worry about how to interpolate arbitrarily.

## TODO
- [x] Update documentation/examples/tutorials to exaplain this funcationality
- [x] Consider adding a warning if the user gives a range which does not overlap fully or at all with the experiment. I feel less strongly about this since a bad choice of range won't compromise the fit, (and as mentioned above, we can't stop them manually using the values in a future calculation anyway), but it might be helpful as a sanity check.

#77 