### PR TITLE
limit numpy to <2 for build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "Cython",
     "pybind11",
     # See https://numpy.org/devdocs/user/troubleshooting-importerror.html#c-api-incompatibility
-    "oldest-supported-numpy",
+    "numpy<2",
     "scipy",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This replaces `ldest-supported-numpy` with `numpy<2` in pyproject.toml to ensure c extension are built agains nunpy 1.x ABI
which fixes this [run](https://github.com/muon-spectroscopy-computational-project/muspinsim/actions/runs/18470405166/job/52625634742#step:4:1570) error