### PR TITLE
liminitng numpy to <2 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ def setup():
         setup_requires=["numpy"],
         install_requires=[
             "ase",
-            "numpy",
+            "numpy<2",
             "scipy",
             "soprano",
             "lark",


### PR DESCRIPTION
The build wheel [run](https://github.com/muon-spectroscopy-computational-project/muspinsim/actions/runs/18490505648/job/52682756635) still fails. Which installs numpy 2 for the test of  wheels.
Found this numpy dependency in setup.py which might be causing the issues. 